### PR TITLE
feat: agentscore CLI npm package

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,446 @@
+{
+  "name": "agentscore",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentscore",
+      "version": "0.1.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "open": "^10.1.0",
+        "ora": "^8.0.1"
+      },
+      "bin": {
+        "agentscore": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agentscore",
+  "version": "0.1.0",
+  "description": "Score and share your Claude Code agent ecosystem setup",
+  "type": "module",
+  "bin": {
+    "agentscore": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "ts-node src/cli.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": ["dist"],
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "ora": "^8.0.1",
+    "open": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/cli/src/auth.ts
+++ b/cli/src/auth.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const AUTH_DIR = path.join(os.homedir(), ".agentscore");
+const AUTH_FILE = path.join(AUTH_DIR, "auth.json");
+
+interface AuthData {
+  token: string;
+  username: string;
+  github?: string;
+  expiresAt?: string;
+}
+
+function ensureAuthDir(): void {
+  try {
+    fs.mkdirSync(AUTH_DIR, { recursive: true });
+  } catch {
+    // Already exists or can't create — surface errors downstream
+  }
+}
+
+export function getToken(): AuthData | null {
+  try {
+    const raw = fs.readFileSync(AUTH_FILE, "utf-8");
+    return JSON.parse(raw) as AuthData;
+  } catch {
+    return null;
+  }
+}
+
+export function saveToken(data: AuthData): void {
+  ensureAuthDir();
+  fs.writeFileSync(AUTH_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+}
+
+export function clearToken(): void {
+  try {
+    fs.unlinkSync(AUTH_FILE);
+  } catch {
+    // File doesn't exist — that's fine
+  }
+}
+
+export function isTokenExpired(data: AuthData): boolean {
+  if (data.expiresAt === undefined) return false;
+  return new Date(data.expiresAt) <= new Date();
+}

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import chalk from "chalk";
+import { runExport } from "./commands/export.js";
+import { runLogin } from "./commands/login.js";
+import { runLogout } from "./commands/logout.js";
+import { runWhoami } from "./commands/whoami.js";
+
+const VERSION = "0.1.0";
+
+function printHelp(): void {
+  process.stdout.write(
+    chalk.bold.white("\nagentscore") +
+      chalk.gray(` v${VERSION}`) +
+      chalk.white(" — Score and share your Claude Code agent ecosystem\n\n") +
+      chalk.bold("Usage:\n") +
+      chalk.white("  agentscore <command>\n\n") +
+      chalk.bold("Commands:\n") +
+      chalk.cyan("  export  ") +
+      chalk.white("Scan ~/.claude/ and submit a manifest to AgentScore\n") +
+      chalk.cyan("  login   ") +
+      chalk.white("Authenticate via GitHub device flow\n") +
+      chalk.cyan("  logout  ") +
+      chalk.white("Clear stored credentials\n") +
+      chalk.cyan("  whoami  ") +
+      chalk.white("Show the currently logged-in user\n\n") +
+      chalk.bold("Options:\n") +
+      chalk.cyan("  --help     ") +
+      chalk.white("Show this help message\n") +
+      chalk.cyan("  --version  ") +
+      chalk.white("Print the CLI version\n\n") +
+      chalk.gray("Environment:\n") +
+      chalk.gray("  AGENTSCORE_API_URL  Override API endpoint (default: https://agentscore.dev)\n") +
+      "\n"
+  );
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (command === "--version" || command === "-v") {
+    process.stdout.write(`${VERSION}\n`);
+    return;
+  }
+
+  if (command === "--help" || command === "-h" || command === undefined) {
+    printHelp();
+    return;
+  }
+
+  switch (command) {
+    case "export":
+      await runExport();
+      break;
+    case "login":
+      await runLogin();
+      break;
+    case "logout":
+      runLogout();
+      break;
+    case "whoami":
+      runWhoami();
+      break;
+    default:
+      process.stdout.write(
+        chalk.red(`Unknown command: ${chalk.bold(command)}\n\n`)
+      );
+      printHelp();
+      process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(chalk.red(`Unexpected error: ${String(err)}\n`));
+  process.exit(1);
+});

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -1,0 +1,131 @@
+import readline from "readline";
+import chalk from "chalk";
+import ora from "ora";
+import { buildManifest, AgentScoreManifest } from "../scanner.js";
+import { getToken, isTokenExpired } from "../auth.js";
+import { runLogin } from "./login.js";
+
+const API_URL = process.env["AGENTSCORE_API_URL"] ?? "https://agentscore.dev";
+
+function colorizeManifest(manifest: AgentScoreManifest): string {
+  const json = JSON.stringify(manifest, null, 2);
+  return json
+    .split("\n")
+    .map((line) => {
+      // Key lines
+      if (/^\s+"[^"]+":/.test(line)) {
+        return line.replace(/"([^"]+)"(:)/, (_, key, colon) => {
+          return chalk.cyan(`"${key}"`) + chalk.white(colon);
+        });
+      }
+      return chalk.white(line);
+    })
+    .join("\n");
+}
+
+function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+export async function runExport(): Promise<void> {
+  // 1. Determine username from stored auth or prompt
+  let auth = getToken();
+  let username = auth?.username ?? "";
+  let github = auth?.github;
+
+  if (username === "") {
+    username = await prompt(chalk.cyan("Enter your username for the manifest: "));
+    username = username.trim();
+    if (username === "") {
+      process.stdout.write(chalk.red("Username is required.\n"));
+      return;
+    }
+  }
+
+  // 2. Build manifest
+  const scanSpinner = ora("Scanning ~/.claude/ ...").start();
+  let manifest: AgentScoreManifest;
+  try {
+    manifest = buildManifest(username, github);
+    scanSpinner.succeed(chalk.green("Scan complete."));
+  } catch (err) {
+    scanSpinner.fail(chalk.red(`Scan failed: ${String(err)}`));
+    return;
+  }
+
+  // 3. Pretty-print manifest
+  process.stdout.write("\n" + colorizeManifest(manifest) + "\n\n");
+
+  // 4. Confirm submission
+  const answer = await prompt(chalk.bold("Submit this manifest to AgentScore? (y/n): "));
+  if (answer.trim().toLowerCase() !== "y") {
+    process.stdout.write(chalk.yellow("Submission cancelled.\n"));
+    return;
+  }
+
+  // 5. Ensure auth — run login flow if needed
+  auth = getToken();
+  if (auth === null || isTokenExpired(auth)) {
+    process.stdout.write(
+      chalk.yellow("\nYou need to log in before submitting.\n\n")
+    );
+    await runLogin();
+    auth = getToken();
+    if (auth === null) {
+      process.stdout.write(chalk.red("Login failed. Cannot submit manifest.\n"));
+      return;
+    }
+  }
+
+  // 6. POST manifest
+  const submitSpinner = ora("Submitting manifest...").start();
+
+  try {
+    const res = await fetch(`${API_URL}/api/profiles`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${auth.token}`,
+      },
+      body: JSON.stringify(manifest),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      submitSpinner.fail(
+        chalk.red(`Submission failed (${res.status}): ${body}`)
+      );
+      return;
+    }
+
+    const data = (await res.json()) as { profileUrl?: string; username?: string };
+    submitSpinner.succeed(chalk.green("Manifest submitted successfully."));
+
+    if (data.profileUrl !== undefined) {
+      process.stdout.write(
+        "\n" +
+          chalk.cyan("Your profile: ") +
+          chalk.bold.white(data.profileUrl) +
+          "\n"
+      );
+    } else {
+      process.stdout.write(
+        "\n" +
+          chalk.cyan("View your profile at: ") +
+          chalk.bold.white(`${API_URL}/u/${manifest.username}`) +
+          "\n"
+      );
+    }
+  } catch (err) {
+    submitSpinner.fail(chalk.red(`Network error: ${String(err)}`));
+  }
+}

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,0 +1,100 @@
+import chalk from "chalk";
+import ora from "ora";
+import open from "open";
+import { saveToken } from "../auth.js";
+
+const API_URL = process.env["AGENTSCORE_API_URL"] ?? "https://agentscore.dev";
+
+interface DeviceResponse {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  expiresIn: number;
+  interval: number;
+}
+
+interface PollResponse {
+  status: "pending" | "complete" | "expired";
+  token?: string;
+  username?: string;
+  github?: string;
+  expiresAt?: string;
+}
+
+export async function runLogin(): Promise<void> {
+  const spinner = ora("Initiating GitHub device flow...").start();
+
+  let deviceData: DeviceResponse;
+
+  try {
+    const res = await fetch(`${API_URL}/api/auth/device`, { method: "POST" });
+    if (!res.ok) {
+      spinner.fail(chalk.red(`Device flow failed: ${res.status} ${res.statusText}`));
+      return;
+    }
+    deviceData = (await res.json()) as DeviceResponse;
+  } catch (err) {
+    spinner.fail(chalk.red(`Could not reach AgentScore API: ${String(err)}`));
+    return;
+  }
+
+  spinner.stop();
+
+  process.stdout.write(
+    chalk.cyan("\nOpen the following URL to authenticate:\n") +
+      chalk.bold.white(`  ${deviceData.verificationUri}\n\n`) +
+      chalk.cyan("Enter code: ") +
+      chalk.bold.yellow(deviceData.userCode) +
+      "\n\n"
+  );
+
+  try {
+    await open(deviceData.verificationUri);
+  } catch {
+    // Non-fatal — user can open manually
+  }
+
+  const pollSpinner = ora("Waiting for GitHub authorisation...").start();
+  const intervalMs = (deviceData.interval ?? 5) * 1000;
+  const expiresAt = Date.now() + deviceData.expiresIn * 1000;
+
+  while (Date.now() < expiresAt) {
+    await sleep(intervalMs);
+
+    let poll: PollResponse;
+    try {
+      const res = await fetch(`${API_URL}/api/auth/device/poll`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deviceCode: deviceData.deviceCode }),
+      });
+      poll = (await res.json()) as PollResponse;
+    } catch {
+      continue;
+    }
+
+    if (poll.status === "complete" && poll.token !== undefined) {
+      saveToken({
+        token: poll.token,
+        username: poll.username ?? "",
+        ...(poll.github !== undefined ? { github: poll.github } : {}),
+        ...(poll.expiresAt !== undefined ? { expiresAt: poll.expiresAt } : {}),
+      });
+      pollSpinner.succeed(
+        chalk.green(`Logged in as ${chalk.bold(poll.username ?? poll.github ?? "unknown")}`)
+      );
+      return;
+    }
+
+    if (poll.status === "expired") {
+      pollSpinner.fail(chalk.red("Device code expired. Run `agentscore login` again."));
+      return;
+    }
+  }
+
+  pollSpinner.fail(chalk.red("Timed out waiting for authorisation."));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/cli/src/commands/logout.ts
+++ b/cli/src/commands/logout.ts
@@ -1,0 +1,15 @@
+import chalk from "chalk";
+import { clearToken, getToken } from "../auth.js";
+
+export function runLogout(): void {
+  const existing = getToken();
+  if (existing === null) {
+    process.stdout.write(chalk.yellow("No active session found.\n"));
+    return;
+  }
+  clearToken();
+  process.stdout.write(
+    chalk.green(`Logged out${existing.username ? ` (was ${chalk.bold(existing.username)})` : ""}.`) +
+      "\n"
+  );
+}

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -1,0 +1,34 @@
+import chalk from "chalk";
+import { getToken, isTokenExpired } from "../auth.js";
+
+export function runWhoami(): void {
+  const auth = getToken();
+
+  if (auth === null) {
+    process.stdout.write(chalk.yellow("Not logged in. Run `agentscore login` to authenticate.\n"));
+    return;
+  }
+
+  if (isTokenExpired(auth)) {
+    process.stdout.write(
+      chalk.yellow("Session expired. Run `agentscore login` to re-authenticate.\n")
+    );
+    return;
+  }
+
+  process.stdout.write(
+    chalk.cyan("Logged in as: ") + chalk.bold.white(auth.username) + "\n"
+  );
+
+  if (auth.github !== undefined) {
+    process.stdout.write(chalk.cyan("GitHub: ") + chalk.white(auth.github) + "\n");
+  }
+
+  if (auth.expiresAt !== undefined) {
+    process.stdout.write(
+      chalk.cyan("Session expires: ") +
+        chalk.white(new Date(auth.expiresAt).toLocaleString()) +
+        "\n"
+    );
+  }
+}

--- a/cli/src/scanner.ts
+++ b/cli/src/scanner.ts
@@ -1,0 +1,312 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+export interface AgentScoreManifest {
+  version: "1.0";
+  exportedAt: string;
+  generator: "agentscore-cli" | "manual";
+  username: string;
+  github?: string;
+  agents: { count: number; names: string[]; hasSharedDir: boolean };
+  memory: {
+    hasMemoryMd: boolean;
+    memoryFileCount: number;
+    memoryCategories: string[];
+    projectMemoryDirs: number;
+  };
+  mcpServers: { count: number; names: string[] };
+  hooks: { events: string[]; totalHookCount: number; hasStatusLine: boolean };
+  commands: { count: number; names: string[] };
+  projects: { count: number; hasClaudeMd: boolean };
+  workflows: {
+    hasCronJobs: boolean;
+    hasPlugins: boolean;
+    pluginNames: string[];
+    hasCustomProxy: boolean;
+    hasChannels: boolean;
+    channelTypes: string[];
+  };
+}
+
+const CLAUDE_DIR = path.join(os.homedir(), ".claude");
+
+function safeReadDir(dirPath: string): string[] {
+  try {
+    return fs.readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function safeReadJson(filePath: string): Record<string, unknown> | null {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function isDirectory(fullPath: string): boolean {
+  try {
+    return fs.statSync(fullPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function scanAgents(): AgentScoreManifest["agents"] {
+  const agentsDir = path.join(CLAUDE_DIR, "agents");
+  const entries = safeReadDir(agentsDir);
+  const mdFiles = entries.filter(
+    (e) => e.endsWith(".md") && !isDirectory(path.join(agentsDir, e))
+  );
+  const names = mdFiles.map((f) => path.basename(f, ".md"));
+  const hasSharedDir = isDirectory(path.join(agentsDir, "shared"));
+  return { count: names.length, names, hasSharedDir };
+}
+
+function scanMemory(): AgentScoreManifest["memory"] {
+  const projectsDir = path.join(CLAUDE_DIR, "projects");
+  const projectEntries = safeReadDir(projectsDir);
+
+  let memoryMdPath: string | null = null;
+  let projectMemoryDirs = 0;
+
+  for (const entry of projectEntries) {
+    const memDir = path.join(projectsDir, entry, "memory");
+    const memMd = path.join(memDir, "MEMORY.md");
+    if (fileExists(memMd)) {
+      projectMemoryDirs++;
+      if (memoryMdPath === null) {
+        memoryMdPath = memMd;
+      }
+    }
+  }
+
+  const hasMemoryMd = memoryMdPath !== null;
+
+  if (!hasMemoryMd || memoryMdPath === null) {
+    return {
+      hasMemoryMd: false,
+      memoryFileCount: 0,
+      memoryCategories: [],
+      projectMemoryDirs: 0,
+    };
+  }
+
+  // Count .md files in the memory dir (sibling to MEMORY.md)
+  const memDir = path.dirname(memoryMdPath);
+  const memFiles = safeReadDir(memDir).filter(
+    (f) => f.endsWith(".md") && !isDirectory(path.join(memDir, f))
+  );
+
+  // Extract ## Heading lines from MEMORY.md — we read only the headings, not body content
+  let memoryCategories: string[] = [];
+  try {
+    const content = fs.readFileSync(memoryMdPath, "utf-8");
+    memoryCategories = content
+      .split("\n")
+      .filter((line) => /^## /.test(line))
+      .map((line) => line.replace(/^## /, "").trim());
+  } catch {
+    memoryCategories = [];
+  }
+
+  return {
+    hasMemoryMd: true,
+    memoryFileCount: memFiles.length,
+    memoryCategories,
+    projectMemoryDirs,
+  };
+}
+
+function scanMcpServers(): AgentScoreManifest["mcpServers"] {
+  const mcpPath = path.join(CLAUDE_DIR, "mcp.json");
+  const mcpJson = safeReadJson(mcpPath);
+
+  const names: string[] = [];
+
+  if (mcpJson !== null) {
+    // Only read top-level keys under "mcpServers" — never values
+    const servers = mcpJson["mcpServers"];
+    if (servers !== null && typeof servers === "object" && !Array.isArray(servers)) {
+      names.push(...Object.keys(servers as Record<string, unknown>));
+    }
+  }
+
+  // Also check settings.json enabledPlugins for plugin-based MCP servers
+  const settingsPath = path.join(CLAUDE_DIR, "settings.json");
+  const settings = safeReadJson(settingsPath);
+  if (settings !== null) {
+    const plugins = settings["enabledPlugins"];
+    if (plugins !== null && typeof plugins === "object" && !Array.isArray(plugins)) {
+      const pluginKeys = Object.keys(plugins as Record<string, unknown>);
+      for (const key of pluginKeys) {
+        if (!names.includes(key)) {
+          names.push(key);
+        }
+      }
+    }
+  }
+
+  return { count: names.length, names };
+}
+
+function scanHooks(): AgentScoreManifest["hooks"] {
+  const settingsPath = path.join(CLAUDE_DIR, "settings.json");
+  const settings = safeReadJson(settingsPath);
+
+  if (settings === null) {
+    return { events: [], totalHookCount: 0, hasStatusLine: false };
+  }
+
+  const hooksRaw = settings["hooks"];
+  let events: string[] = [];
+  let totalHookCount = 0;
+
+  if (hooksRaw !== null && typeof hooksRaw === "object" && !Array.isArray(hooksRaw)) {
+    const hooksObj = hooksRaw as Record<string, unknown>;
+    events = Object.keys(hooksObj);
+
+    for (const event of events) {
+      const eventHooks = hooksObj[event];
+      if (Array.isArray(eventHooks)) {
+        // Each entry may be { hooks: [...] } or a hook directly
+        for (const entry of eventHooks) {
+          if (
+            typeof entry === "object" &&
+            entry !== null &&
+            "hooks" in (entry as Record<string, unknown>)
+          ) {
+            const inner = (entry as Record<string, unknown>)["hooks"];
+            if (Array.isArray(inner)) {
+              totalHookCount += inner.length;
+            }
+          } else {
+            totalHookCount += 1;
+          }
+        }
+      }
+    }
+  }
+
+  const hasStatusLine = "statusLine" in settings && settings["statusLine"] !== null;
+
+  return { events, totalHookCount, hasStatusLine };
+}
+
+function scanCommands(): AgentScoreManifest["commands"] {
+  const commandsDir = path.join(CLAUDE_DIR, "commands");
+  const entries = safeReadDir(commandsDir);
+  const mdFiles = entries.filter(
+    (e) => e.endsWith(".md") && !isDirectory(path.join(commandsDir, e))
+  );
+  const names = mdFiles.map((f) => path.basename(f, ".md"));
+  return { count: names.length, names };
+}
+
+function scanProjects(): AgentScoreManifest["projects"] {
+  const projectsDir = path.join(CLAUDE_DIR, "projects");
+  const entries = safeReadDir(projectsDir);
+  const dirs = entries.filter((e) => isDirectory(path.join(projectsDir, e)));
+
+  let hasClaudeMd = false;
+  for (const dir of dirs) {
+    if (fileExists(path.join(projectsDir, dir, "CLAUDE.md"))) {
+      hasClaudeMd = true;
+      break;
+    }
+  }
+
+  return { count: dirs.length, hasClaudeMd };
+}
+
+function scanWorkflows(): AgentScoreManifest["workflows"] {
+  const settingsPath = path.join(CLAUDE_DIR, "settings.json");
+  const settings = safeReadJson(settingsPath);
+
+  let hasCronJobs = false;
+  let pluginNames: string[] = [];
+  let hasCustomProxy = false;
+  let channelTypes: string[] = [];
+
+  if (settings !== null) {
+    // Check crons field
+    hasCronJobs =
+      "crons" in settings &&
+      settings["crons"] !== null &&
+      settings["crons"] !== undefined;
+
+    // enabledPlugins keys
+    const plugins = settings["enabledPlugins"];
+    if (plugins !== null && typeof plugins === "object" && !Array.isArray(plugins)) {
+      pluginNames = Object.keys(plugins as Record<string, unknown>);
+    }
+
+    // Custom proxy
+    hasCustomProxy =
+      ("proxy" in settings && settings["proxy"] !== null) ||
+      ("fallbackModel" in settings && settings["fallbackModel"] !== null);
+
+    // Channels
+    const channelsRaw = settings["channels"];
+    if (
+      channelsRaw !== null &&
+      typeof channelsRaw === "object" &&
+      !Array.isArray(channelsRaw)
+    ) {
+      channelTypes = Object.keys(channelsRaw as Record<string, unknown>);
+    }
+  }
+
+  // Also check channels directory for channel types
+  if (channelTypes.length === 0) {
+    const channelsDir = path.join(CLAUDE_DIR, "channels");
+    const entries = safeReadDir(channelsDir);
+    if (entries.length > 0) {
+      channelTypes = entries.filter((e) =>
+        isDirectory(path.join(channelsDir, e))
+      );
+    }
+  }
+
+  const hasPlugins = pluginNames.length > 0;
+  const hasChannels = channelTypes.length > 0;
+
+  return {
+    hasCronJobs,
+    hasPlugins,
+    pluginNames,
+    hasCustomProxy,
+    hasChannels,
+    channelTypes,
+  };
+}
+
+export function buildManifest(username: string, github?: string): AgentScoreManifest {
+  return {
+    version: "1.0",
+    exportedAt: new Date().toISOString(),
+    generator: "agentscore-cli",
+    username,
+    ...(github !== undefined ? { github } : {}),
+    agents: scanAgents(),
+    memory: scanMemory(),
+    mcpServers: scanMcpServers(),
+    hooks: scanHooks(),
+    commands: scanCommands(),
+    projects: scanProjects(),
+    workflows: scanWorkflows(),
+  };
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "agent-score",
   "version": "0.1.0",
   "private": true,
+  "workspaces": ["cli"],
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## What
Adds a `cli/` workspace containing the `agentscore` npm package — a Node.js CLI tool that scans `~/.claude/` and submits a scored manifest to the AgentScore platform.

## Why
Users need a local CLI to scan their Claude Code setup and submit it for scoring without manually constructing JSON.

## Commands implemented
- `agentscore export` — scans `~/.claude/`, pretty-prints manifest, prompts for confirmation, runs device-flow login if needed, then POSTs to `/api/profiles`
- `agentscore login` — GitHub device flow: displays code + verification URL, opens browser, polls until authorised, saves token to `~/.agentscore/auth.json`
- `agentscore logout` — clears `~/.agentscore/auth.json`
- `agentscore whoami` — shows current user and session expiry
- `--help` / `--version`

## Acceptance Criteria
- [x] TypeScript strict mode, zero `any` types
- [x] `tsc` builds with zero errors
- [x] Scanner never throws — missing `~/.claude/` yields empty manifest
- [x] Privacy rules enforced: only MCP server names read (not args/env), only hook event names + count read (not command strings), `.md` file body never read (except MEMORY.md `## Heading` lines for categories)
- [x] Auth stored at `~/.agentscore/auth.json` with mode 0600
- [x] `AGENTSCORE_API_URL` env var overrides API endpoint
- [x] `cli/` added as npm workspace in root `package.json`

## Test Plan
```bash
cd /Users/ricky/Dev/agent-score/cli
npm run build           # must compile with zero errors
node dist/cli.js --help
node dist/cli.js --version
# Scanner smoke test:
node --input-type=module -e "import { buildManifest } from './dist/scanner.js'; console.log(JSON.stringify(buildManifest('testuser'), null, 2));"
# Auth round-trip:
node dist/cli.js whoami   # expect: not logged in
node dist/cli.js logout   # expect: no active session
# Export (with local API):
AGENTSCORE_API_URL=http://localhost:3000 node dist/cli.js export
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)