### PR TITLE
feat: one-click packaging — CLI flags, upload page, setup guide

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { runLogin } from "./commands/login.js";
 import { runLogout } from "./commands/logout.js";
 import { runWhoami } from "./commands/whoami.js";
 
-const VERSION = "0.1.0";
+const VERSION = "0.2.0";
 
 function printHelp(): void {
   process.stdout.write(
@@ -14,7 +14,7 @@ function printHelp(): void {
       chalk.gray(` v${VERSION}`) +
       chalk.white(" — Score and share your Claude Code agent ecosystem\n\n") +
       chalk.bold("Usage:\n") +
-      chalk.white("  agentscore <command>\n\n") +
+      chalk.white("  agentscore <command> [options]\n\n") +
       chalk.bold("Commands:\n") +
       chalk.cyan("  export  ") +
       chalk.white("Scan ~/.claude/ and submit a manifest to AgentScore\n") +
@@ -24,11 +24,23 @@ function printHelp(): void {
       chalk.white("Clear stored credentials\n") +
       chalk.cyan("  whoami  ") +
       chalk.white("Show the currently logged-in user\n\n") +
+      chalk.bold("Export options:\n") +
+      chalk.cyan("  --auto   ") +
+      chalk.white("Skip review prompt and submit immediately\n") +
+      chalk.cyan("  --save   ") +
+      chalk.white("Save manifest to agentscore-manifest.json instead of submitting\n\n") +
       chalk.bold("Options:\n") +
       chalk.cyan("  --help     ") +
       chalk.white("Show this help message\n") +
       chalk.cyan("  --version  ") +
       chalk.white("Print the CLI version\n\n") +
+      chalk.gray("Quick start:\n") +
+      chalk.white("  npx agentscore export          ") +
+      chalk.gray("# Scan, review, submit\n") +
+      chalk.white("  npx agentscore export --save   ") +
+      chalk.gray("# Save manifest to inspect first\n") +
+      chalk.white("  npx agentscore export --auto   ") +
+      chalk.gray("# Submit without review prompt\n\n") +
       chalk.gray("Environment:\n") +
       chalk.gray("  AGENTSCORE_API_URL  Override API endpoint (default: https://agentscore.dev)\n") +
       "\n"
@@ -50,9 +62,14 @@ async function main(): Promise<void> {
   }
 
   switch (command) {
-    case "export":
-      await runExport();
+    case "export": {
+      const flags = new Set(args.slice(1));
+      await runExport({
+        auto: flags.has("--auto"),
+        save: flags.has("--save"),
+      });
       break;
+    }
     case "login":
       await runLogin();
       break;

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -1,11 +1,19 @@
+import fs from "fs";
+import path from "path";
 import readline from "readline";
 import chalk from "chalk";
 import ora from "ora";
 import { buildManifest, AgentScoreManifest } from "../scanner.js";
 import { getToken, isTokenExpired } from "../auth.js";
 import { runLogin } from "./login.js";
+import { previewScore } from "../score-preview.js";
 
 const API_URL = process.env["AGENTSCORE_API_URL"] ?? "https://agentscore.dev";
+
+export interface ExportOptions {
+  auto: boolean;
+  save: boolean;
+}
 
 function colorizeManifest(manifest: AgentScoreManifest): string {
   const json = JSON.stringify(manifest, null, 2);
@@ -36,7 +44,7 @@ function prompt(question: string): Promise<string> {
   });
 }
 
-export async function runExport(): Promise<void> {
+export async function runExport(options: ExportOptions): Promise<void> {
   // 1. Determine username from stored auth or prompt
   let auth = getToken();
   let username = auth?.username ?? "";
@@ -62,17 +70,39 @@ export async function runExport(): Promise<void> {
     return;
   }
 
-  // 3. Pretty-print manifest
-  process.stdout.write("\n" + colorizeManifest(manifest) + "\n\n");
+  // 3. Show estimated score preview
+  previewScore(manifest);
 
-  // 4. Confirm submission
-  const answer = await prompt(chalk.bold("Submit this manifest to AgentScore? (y/n): "));
-  if (answer.trim().toLowerCase() !== "y") {
-    process.stdout.write(chalk.yellow("Submission cancelled.\n"));
+  // 4. Handle --save: write manifest to file and exit
+  if (options.save) {
+    const outPath = path.resolve("agentscore-manifest.json");
+    fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2) + "\n");
+    process.stdout.write(
+      chalk.green("Manifest saved to: ") + chalk.bold.white(outPath) + "\n"
+    );
+    process.stdout.write(
+      chalk.gray("Inspect the file, then run ") +
+        chalk.cyan("agentscore export") +
+        chalk.gray(" to submit.\n")
+    );
     return;
   }
 
-  // 5. Ensure auth — run login flow if needed
+  // 5. Pretty-print manifest (skip in --auto mode)
+  if (!options.auto) {
+    process.stdout.write(colorizeManifest(manifest) + "\n\n");
+  }
+
+  // 6. Confirm submission (skip in --auto mode)
+  if (!options.auto) {
+    const answer = await prompt(chalk.bold("Submit this manifest to AgentScore? (y/n): "));
+    if (answer.trim().toLowerCase() !== "y") {
+      process.stdout.write(chalk.yellow("Submission cancelled.\n"));
+      return;
+    }
+  }
+
+  // 7. Ensure auth — run login flow if needed
   auth = getToken();
   if (auth === null || isTokenExpired(auth)) {
     process.stdout.write(
@@ -86,7 +116,7 @@ export async function runExport(): Promise<void> {
     }
   }
 
-  // 6. POST manifest
+  // 8. POST manifest
   const submitSpinner = ora("Submitting manifest...").start();
 
   try {

--- a/cli/src/score-preview.ts
+++ b/cli/src/score-preview.ts
@@ -1,0 +1,155 @@
+import chalk from "chalk";
+import type { AgentScoreManifest } from "./scanner.js";
+
+interface DimPreview {
+  label: string;
+  score: number;
+  max: number;
+}
+
+const MCP_CODE_TOOLS = ["github", "gitlab", "bitbucket", "jira", "linear"];
+const MCP_DESIGN_TOOLS = ["figma", "tldraw", "canva"];
+const MCP_COMM_TOOLS = ["telegram", "slack", "discord", "email", "gmail"];
+const MCP_BROWSER_TOOLS = ["playwright", "puppeteer", "selenium", "browserbase"];
+const WORKFLOW_KEYWORDS = ["deploy", "build", "review", "test", "cycle"];
+const META_KEYWORDS = ["status", "daily", "start", "switch"];
+const ROLE_KEYWORDS = ["dev", "frontend", "backend", "qa", "test", "ops", "deploy", "pm", "product", "design", "finance", "research", "ceo", "manager"];
+
+function namesMatch(names: string[], keywords: string[]): boolean {
+  return names.some((n) => keywords.some((kw) => n.toLowerCase().includes(kw)));
+}
+
+function cap(v: number, max: number): number {
+  return Math.min(v, max);
+}
+
+function scoreAutomation(m: AgentScoreManifest): number {
+  let s = 0;
+  if (m.hooks.totalHookCount > 0) s += 2;
+  if (m.hooks.events.includes("UserPromptSubmit")) s += 1;
+  if (m.hooks.events.includes("PreToolUse")) s += 1;
+  if (m.hooks.events.includes("Stop")) s += 1;
+  if (m.hooks.totalHookCount >= 3) s += 1;
+  if (m.hooks.totalHookCount >= 6) s += 1;
+  if (m.hooks.hasStatusLine) s += 1;
+  if (m.workflows.hasCronJobs) s += 1;
+  if (m.workflows.hasCustomProxy) s += 1;
+  return cap(s, 10);
+}
+
+function scoreMemory(m: AgentScoreManifest): number {
+  let s = 0;
+  if (m.memory.hasMemoryMd) s += 2;
+  if (m.memory.memoryFileCount >= 3) s += 1;
+  if (m.memory.memoryFileCount >= 6) s += 1;
+  if (m.memory.memoryFileCount >= 10) s += 1;
+  if (m.memory.memoryCategories.length >= 2) s += 1;
+  if (m.memory.memoryCategories.length >= 4) s += 1;
+  if (m.memory.projectMemoryDirs >= 1) s += 1;
+  if (m.memory.projectMemoryDirs >= 3) s += 1;
+  if (m.memory.projectMemoryDirs >= 5) s += 1;
+  return cap(s, 10);
+}
+
+function scoreAgentCoverage(m: AgentScoreManifest): number {
+  let s = 0;
+  if (m.agents.count > 0) s += 2;
+  if (m.agents.count >= 3) s += 1;
+  if (m.agents.count >= 5) s += 1;
+  if (m.agents.count >= 8) s += 1;
+  if (m.agents.count >= 10) s += 1;
+  if (m.agents.hasSharedDir) s += 1;
+  const lower = m.agents.names.map((n) => n.toLowerCase());
+  if (ROLE_KEYWORDS.some((kw) => lower.some((n) => n.includes(kw)))) s += 1;
+  const matched = new Set<string>();
+  for (const n of lower) for (const kw of ROLE_KEYWORDS) if (n.includes(kw)) matched.add(kw);
+  if (matched.size >= 3) s += 1;
+  if (matched.size >= 5) s += 1;
+  return cap(s, 10);
+}
+
+function scoreToolIntegrations(m: AgentScoreManifest): number {
+  let s = 0;
+  if (m.mcpServers.count > 0) s += 2;
+  if (m.mcpServers.count >= 2) s += 1;
+  if (m.mcpServers.count >= 4) s += 1;
+  if (m.mcpServers.count >= 6) s += 1;
+  if (m.mcpServers.count >= 8) s += 1;
+  if (namesMatch(m.mcpServers.names, MCP_CODE_TOOLS)) s += 1;
+  if (namesMatch(m.mcpServers.names, MCP_DESIGN_TOOLS)) s += 1;
+  if (namesMatch(m.mcpServers.names, MCP_COMM_TOOLS)) s += 1;
+  if (namesMatch(m.mcpServers.names, MCP_BROWSER_TOOLS)) s += 1;
+  return cap(s, 10);
+}
+
+function scoreSkillBreadth(m: AgentScoreManifest): number {
+  let s = 0;
+  if (m.commands.count > 0) s += 2;
+  if (m.commands.count >= 3) s += 1;
+  if (m.commands.count >= 5) s += 1;
+  if (m.commands.count >= 8) s += 1;
+  if (m.commands.count >= 12) s += 1;
+  if (m.commands.count >= 16) s += 1;
+  if (m.commands.count >= 20) s += 1;
+  if (namesMatch(m.commands.names, WORKFLOW_KEYWORDS)) s += 1;
+  if (namesMatch(m.commands.names, META_KEYWORDS)) s += 1;
+  return cap(s, 10);
+}
+
+function scoreWorkflowDepth(m: AgentScoreManifest): number {
+  let s = 0;
+  if (m.workflows.hasPlugins) s += 1;
+  if (m.workflows.pluginNames.length >= 2) s += 1;
+  if (m.workflows.hasChannels) s += 1;
+  if (m.workflows.channelTypes.length >= 2) s += 1;
+  if (m.hooks.totalHookCount > 0 && m.commands.count > 0) s += 1;
+  if (m.agents.count > 0 && m.commands.count > 0) s += 1;
+  if (m.mcpServers.count > 0 && m.hooks.totalHookCount > 0) s += 1;
+  if (m.agents.count > 0 && m.mcpServers.count > 0 && m.hooks.totalHookCount > 0 && m.commands.count > 0) s += 2;
+  if (m.memory.projectMemoryDirs >= 3) s += 1;
+  return cap(s, 10);
+}
+
+function getTier(composite: number): string {
+  if (composite <= 2.0) return "Beginner";
+  if (composite <= 4.0) return "Intermediate";
+  if (composite <= 6.0) return "Advanced";
+  if (composite <= 8.0) return "Expert";
+  return "Master";
+}
+
+function bar(score: number, max: number, color: (text: string) => string): string {
+  const filled = Math.round((score / max) * 20);
+  const empty = 20 - filled;
+  return color("█".repeat(filled)) + chalk.gray("░".repeat(empty));
+}
+
+export function previewScore(manifest: AgentScoreManifest): void {
+  const dims: DimPreview[] = [
+    { label: "Automation", score: scoreAutomation(manifest), max: 10 },
+    { label: "Memory", score: scoreMemory(manifest), max: 10 },
+    { label: "Agent Coverage", score: scoreAgentCoverage(manifest), max: 10 },
+    { label: "Tool Integrations", score: scoreToolIntegrations(manifest), max: 10 },
+    { label: "Skill Breadth", score: scoreSkillBreadth(manifest), max: 10 },
+    { label: "Workflow Depth", score: scoreWorkflowDepth(manifest), max: 10 },
+  ];
+
+  const sum = dims.reduce((s, d) => s + d.score, 0);
+  const composite = Math.round((sum / 6) * 10) / 10;
+  const tier = getTier(composite);
+
+  const colors = [chalk.blue, chalk.green, chalk.magenta, chalk.yellow, chalk.red, chalk.cyan];
+
+  process.stdout.write("\n" + chalk.bold("  Estimated AgentScore Preview\n"));
+  process.stdout.write(chalk.gray("  ─".repeat(24)) + "\n\n");
+
+  for (let i = 0; i < dims.length; i++) {
+    const d = dims[i];
+    const label = d.label.padEnd(18);
+    process.stdout.write(`  ${colors[i](label)} ${bar(d.score, d.max, colors[i])} ${chalk.white(String(d.score).padStart(2))}/${d.max}\n`);
+  }
+
+  process.stdout.write("\n");
+  process.stdout.write(chalk.bold(`  Composite: ${composite} / 10`) + chalk.gray(` (${tier})`) + "\n");
+  process.stdout.write(chalk.gray(`  Calculation: (${dims.map((d) => d.score).join(" + ")}) / 6 = ${composite}`) + "\n\n");
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,9 +130,9 @@ export default function HomePage() {
               variant="outline"
               size="lg"
               className="border-white/20 text-white hover:bg-white/10 px-6 h-11"
-              render={<Link href="https://github.com/wkliwk/agent-score" target="_blank" rel="noopener noreferrer" />}
+              render={<Link href="/upload" />}
             >
-              Get your score
+              Upload manifest
             </Button>
           </div>
 
@@ -256,23 +256,43 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* CTA */}
+      {/* CTA — 30-second setup guide */}
       <section className="px-4 py-16 md:py-24 text-center">
         <div className="mx-auto max-w-xl">
           <h2 className="text-2xl font-semibold tracking-tight text-white md:text-3xl">
             Score your setup in 30 seconds
           </h2>
-          <p className="mt-3 text-white/55 text-sm">
-            Run the CLI, get your score, and share your profile with the community.
+          <p className="mt-3 text-white/55 text-sm mb-8">
+            Three commands. That&apos;s it.
           </p>
-          <div className="mt-6 mx-auto max-w-sm">
-            <div className="flex items-center justify-between rounded-xl bg-[#111] border border-white/10 px-4 py-3">
-              <code className="font-mono text-sm text-emerald-400">
-                npx agentscore export
-              </code>
+
+          <div className="mx-auto max-w-md space-y-3 text-left">
+            <div className="flex items-center gap-3 rounded-xl bg-[#111] border border-white/10 px-4 py-3">
+              <span className="text-xs font-bold text-white/30 w-4">1</span>
+              <code className="flex-1 font-mono text-sm text-emerald-400">npx agentscore export</code>
               <CopyButton text="npx agentscore export" />
             </div>
+            <p className="text-xs text-white/40 pl-7">Scans ~/.claude/ and shows your score preview</p>
+
+            <div className="flex items-center gap-3 rounded-xl bg-[#111] border border-white/10 px-4 py-3">
+              <span className="text-xs font-bold text-white/30 w-4">2</span>
+              <code className="flex-1 font-mono text-sm text-white/60">Review manifest → press <span className="text-emerald-400">y</span> to submit</code>
+            </div>
+            <p className="text-xs text-white/40 pl-7">Your profile goes live at agentscore.dev/u/you</p>
+
+            <div className="flex items-center gap-3 rounded-xl bg-[#111] border border-white/10 px-4 py-3">
+              <span className="text-xs font-bold text-white/30 w-4">3</span>
+              <code className="flex-1 font-mono text-sm text-white/60">Share your profile link</code>
+            </div>
           </div>
+
+          <p className="mt-6 text-xs text-white/30">
+            Or{" "}
+            <Link href="/upload" className="text-indigo-400 hover:underline">
+              upload a manifest manually
+            </Link>
+            {" "}if you prefer.
+          </p>
         </div>
       </section>
 
@@ -291,6 +311,7 @@ export default function HomePage() {
           </span>
           <div className="flex gap-4">
             <Link href="/explore" className="hover:text-white/60 transition-colors">Explore</Link>
+            <Link href="/upload" className="hover:text-white/60 transition-colors">Upload</Link>
             <a
               href="https://github.com/wkliwk/agent-score"
               target="_blank"

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Upload, FileJson, AlertCircle, CheckCircle2, Copy, Check } from "lucide-react";
+import Navbar from "@/components/Navbar";
+
+interface ScorePreview {
+  composite: number;
+  tier: string;
+  dimensions: { label: string; score: number }[];
+}
+
+function validateManifest(json: unknown): string | null {
+  if (typeof json !== "object" || json === null) return "Invalid JSON: expected an object";
+  const m = json as Record<string, unknown>;
+  if (m["version"] !== "1.0") return "Missing or invalid 'version' field (expected '1.0')";
+  if (typeof m["username"] !== "string" || m["username"] === "") return "Missing 'username' field";
+  const requiredSections = ["agents", "memory", "mcpServers", "hooks", "commands", "projects", "workflows"];
+  for (const key of requiredSections) {
+    if (typeof m[key] !== "object" || m[key] === null) return `Missing '${key}' section`;
+  }
+  return null;
+}
+
+function quickScore(json: Record<string, unknown>): ScorePreview {
+  const m = json as {
+    agents: { count: number; names: string[]; hasSharedDir: boolean };
+    memory: { hasMemoryMd: boolean; memoryFileCount: number; memoryCategories: string[]; projectMemoryDirs: number };
+    mcpServers: { count: number; names: string[] };
+    hooks: { events: string[]; totalHookCount: number; hasStatusLine: boolean };
+    commands: { count: number; names: string[] };
+    workflows: { hasCronJobs: boolean; hasPlugins: boolean; pluginNames: string[]; hasCustomProxy: boolean; hasChannels: boolean; channelTypes: string[] };
+  };
+
+  const cap = (v: number, max: number) => Math.min(v, max);
+
+  let auto = 0;
+  if (m.hooks.totalHookCount > 0) auto += 2;
+  if (m.hooks.events.includes("UserPromptSubmit")) auto += 1;
+  if (m.hooks.events.includes("PreToolUse")) auto += 1;
+  if (m.hooks.events.includes("Stop")) auto += 1;
+  if (m.hooks.totalHookCount >= 3) auto += 1;
+  if (m.hooks.totalHookCount >= 6) auto += 1;
+  if (m.hooks.hasStatusLine) auto += 1;
+  if (m.workflows.hasCronJobs) auto += 1;
+  if (m.workflows.hasCustomProxy) auto += 1;
+
+  let mem = 0;
+  if (m.memory.hasMemoryMd) mem += 2;
+  if (m.memory.memoryFileCount >= 3) mem += 1;
+  if (m.memory.memoryFileCount >= 6) mem += 1;
+  if (m.memory.memoryFileCount >= 10) mem += 1;
+  if (m.memory.memoryCategories.length >= 2) mem += 1;
+  if (m.memory.memoryCategories.length >= 4) mem += 1;
+  if (m.memory.projectMemoryDirs >= 1) mem += 1;
+  if (m.memory.projectMemoryDirs >= 3) mem += 1;
+  if (m.memory.projectMemoryDirs >= 5) mem += 1;
+
+  let agent = 0;
+  if (m.agents.count > 0) agent += 2;
+  if (m.agents.count >= 3) agent += 1;
+  if (m.agents.count >= 5) agent += 1;
+  if (m.agents.count >= 8) agent += 1;
+  if (m.agents.count >= 10) agent += 1;
+  if (m.agents.hasSharedDir) agent += 1;
+
+  let tool = 0;
+  if (m.mcpServers.count > 0) tool += 2;
+  if (m.mcpServers.count >= 2) tool += 1;
+  if (m.mcpServers.count >= 4) tool += 1;
+  if (m.mcpServers.count >= 6) tool += 1;
+  if (m.mcpServers.count >= 8) tool += 1;
+
+  let skill = 0;
+  if (m.commands.count > 0) skill += 2;
+  if (m.commands.count >= 3) skill += 1;
+  if (m.commands.count >= 5) skill += 1;
+  if (m.commands.count >= 8) skill += 1;
+  if (m.commands.count >= 12) skill += 1;
+  if (m.commands.count >= 16) skill += 1;
+  if (m.commands.count >= 20) skill += 1;
+
+  let wf = 0;
+  if (m.workflows.hasPlugins) wf += 1;
+  if (m.workflows.pluginNames.length >= 2) wf += 1;
+  if (m.workflows.hasChannels) wf += 1;
+  if (m.hooks.totalHookCount > 0 && m.commands.count > 0) wf += 1;
+  if (m.agents.count > 0 && m.commands.count > 0) wf += 1;
+  if (m.mcpServers.count > 0 && m.hooks.totalHookCount > 0) wf += 1;
+  if (m.agents.count > 0 && m.mcpServers.count > 0 && m.hooks.totalHookCount > 0 && m.commands.count > 0) wf += 2;
+  if (m.memory.projectMemoryDirs >= 3) wf += 1;
+
+  const dims = [
+    { label: "Automation", score: cap(auto, 10) },
+    { label: "Memory", score: cap(mem, 10) },
+    { label: "Agent Coverage", score: cap(agent, 10) },
+    { label: "Tool Integrations", score: cap(tool, 10) },
+    { label: "Skill Breadth", score: cap(skill, 10) },
+    { label: "Workflow Depth", score: cap(wf, 10) },
+  ];
+
+  const sum = dims.reduce((s, d) => s + d.score, 0);
+  const composite = Math.round((sum / 6) * 10) / 10;
+
+  let tier = "Beginner";
+  if (composite > 8) tier = "Master";
+  else if (composite > 6) tier = "Expert";
+  else if (composite > 4) tier = "Advanced";
+  else if (composite > 2) tier = "Intermediate";
+
+  return { composite, tier, dimensions: dims };
+}
+
+const DIM_COLORS = ["#3b82f6", "#10b981", "#8b5cf6", "#f59e0b", "#f43f5e", "#06b6d4"];
+
+export default function UploadPage() {
+  const [jsonText, setJsonText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<ScorePreview | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleScore = useCallback(() => {
+    setError(null);
+    setPreview(null);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonText);
+    } catch {
+      setError("Invalid JSON. Please check your manifest format.");
+      return;
+    }
+
+    const validationError = validateManifest(parsed);
+    if (validationError !== null) {
+      setError(validationError);
+      return;
+    }
+
+    setPreview(quickScore(parsed as Record<string, unknown>));
+  }, [jsonText]);
+
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result;
+      if (typeof text === "string") {
+        setJsonText(text);
+        setError(null);
+        setPreview(null);
+      }
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleCopyCommand = async () => {
+    try {
+      await navigator.clipboard.writeText("npx agentscore export");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch { /* */ }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1 px-4 py-10 md:py-14">
+        <div className="mx-auto max-w-2xl">
+          <h1 className="text-2xl font-bold text-white mb-2">Upload Manifest</h1>
+          <p className="text-sm text-white/50 mb-8">
+            Paste your AgentScore manifest JSON or upload a file to get your score instantly.
+          </p>
+
+          {/* Quick start */}
+          <div className="rounded-xl bg-[#12121a] border border-indigo-500/20 p-5 mb-8">
+            <h2 className="text-xs uppercase tracking-widest text-indigo-400 mb-3">
+              Recommended: Use the CLI
+            </h2>
+            <p className="text-sm text-white/60 mb-3">
+              The fastest way to get your score — one command, 30 seconds:
+            </p>
+            <div className="flex items-center gap-2 rounded-lg bg-black/40 px-4 py-3 font-mono text-sm">
+              <span className="text-emerald-400">$</span>
+              <span className="flex-1 text-white">npx agentscore export</span>
+              <button
+                onClick={handleCopyCommand}
+                className="text-white/40 hover:text-white transition-colors"
+              >
+                {copied ? <Check size={14} className="text-emerald-400" /> : <Copy size={14} />}
+              </button>
+            </div>
+            <p className="text-xs text-white/30 mt-2">
+              Or save first: <code className="text-white/50">npx agentscore export --save</code>
+            </p>
+          </div>
+
+          {/* Upload area */}
+          <div className="space-y-4 mb-8">
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm bg-white/5 border border-white/10 text-white/60 hover:text-white hover:bg-white/10 transition-colors cursor-pointer">
+                <FileJson size={16} />
+                <span>Upload JSON file</span>
+                <input
+                  type="file"
+                  accept=".json,application/json"
+                  onChange={handleFileUpload}
+                  className="hidden"
+                />
+              </label>
+              <span className="text-xs text-white/30">or paste below</span>
+            </div>
+
+            <textarea
+              value={jsonText}
+              onChange={(e) => {
+                setJsonText(e.target.value);
+                setError(null);
+                setPreview(null);
+              }}
+              placeholder='{"version": "1.0", "username": "...", ...}'
+              className="w-full h-64 rounded-xl bg-[#12121a] border border-white/10 p-4 font-mono text-sm text-white/80 placeholder:text-white/20 resize-y focus:outline-none focus:border-indigo-500/50"
+            />
+
+            <button
+              onClick={handleScore}
+              disabled={jsonText.trim() === ""}
+              className="flex items-center gap-2 rounded-lg px-6 py-2.5 text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <Upload size={16} />
+              Score My Manifest
+            </button>
+          </div>
+
+          {/* Error */}
+          {error !== null && (
+            <div className="flex items-start gap-3 rounded-xl bg-red-500/10 border border-red-500/20 p-4 mb-8">
+              <AlertCircle size={18} className="text-red-400 shrink-0 mt-0.5" />
+              <p className="text-sm text-red-300">{error}</p>
+            </div>
+          )}
+
+          {/* Score preview */}
+          {preview !== null && (
+            <div className="rounded-xl bg-[#12121a] border border-white/10 p-6">
+              <div className="flex items-center gap-3 mb-6">
+                <CheckCircle2 size={20} className="text-emerald-500" />
+                <h2 className="text-lg font-semibold text-white">Score Preview</h2>
+              </div>
+
+              <div className="text-center mb-6">
+                <div className="text-5xl font-bold text-white">{preview.composite}</div>
+                <div className="text-sm text-white/40 mt-1">{preview.tier}</div>
+              </div>
+
+              <div className="space-y-3">
+                {preview.dimensions.map((d, i) => (
+                  <div key={d.label} className="flex items-center gap-3">
+                    <span className="text-xs text-white/50 w-32 text-right">{d.label}</span>
+                    <div className="flex-1 h-2 rounded-full bg-white/10 overflow-hidden">
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{
+                          width: `${(d.score / 10) * 100}%`,
+                          backgroundColor: DIM_COLORS[i],
+                        }}
+                      />
+                    </div>
+                    <span className="text-xs font-mono text-white/60 w-8">{d.score}/10</span>
+                  </div>
+                ))}
+              </div>
+
+              <p className="text-xs text-white/30 text-center mt-6">
+                This is a preview. Submit via CLI for your full profile with radar chart and report.
+              </p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- CLI: `--auto` flag (skip review, submit immediately), `--save` flag (save to file), score preview in terminal
- Web: `/upload` page for manual manifest upload with instant scoring
- Landing page: 30-second setup guide replacing the old CTA, "Upload manifest" button

Closes #11

## Test plan
- [ ] CLI: `npx agentscore export --save` creates `agentscore-manifest.json` in cwd
- [ ] CLI: `npx agentscore export` shows score preview with bar chart before submission prompt
- [ ] CLI: `npx agentscore export --auto` skips review prompt (requires auth)
- [ ] Web: Visit `/upload` — paste valid manifest JSON → see score preview with dimension bars
- [ ] Web: Visit `/upload` — paste invalid JSON → see error message
- [ ] Web: Upload a `.json` file → textarea populates
- [ ] Landing page: CTA section shows 3-step setup guide with copy buttons
- [ ] Landing page: "Upload manifest" button links to `/upload`
- [ ] TypeScript: `npx tsc --noEmit` passes (both root and cli/)
- [ ] Tests: `npx vitest run` — 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)