### PR TITLE
feat: OG infographic — visual summary card for social sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@auth/core": "^0.34.3",
         "@base-ui/react": "^1.3.0",
         "@neondatabase/serverless": "^1.0.2",
+        "@vercel/og": "^0.11.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-kit": "^0.31.10",
@@ -3004,6 +3005,15 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
@@ -3313,6 +3323,22 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -4470,6 +4496,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/og": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.11.1.tgz",
+      "integrity": "sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.25.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
@@ -4946,6 +4988,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -5123,6 +5174,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -5448,6 +5508,47 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -6031,6 +6132,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7027,6 +7137,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -7564,6 +7680,18 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/hono": {
@@ -8776,6 +8904,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9714,6 +9852,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9724,6 +9868,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/parse-json": {
@@ -9918,6 +10072,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -10545,6 +10705,28 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/satori": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.25.0.tgz",
+      "integrity": "sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -11045,6 +11227,12 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -11321,6 +11509,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -12177,6 +12371,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -12891,6 +13095,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@auth/core": "^0.34.3",
     "@base-ui/react": "^1.3.0",
     "@neondatabase/serverless": "^1.0.2",
+    "@vercel/og": "^0.11.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-kit": "^0.31.10",

--- a/src/app/api/og/[username]/route.tsx
+++ b/src/app/api/og/[username]/route.tsx
@@ -1,0 +1,353 @@
+import { ImageResponse } from "@vercel/og";
+import { NextRequest } from "next/server";
+import { getMockProfile } from "@/lib/mock-profiles";
+
+export const runtime = "edge";
+
+const DIM_COLORS = ["#3b82f6", "#10b981", "#8b5cf6", "#f59e0b", "#f43f5e", "#06b6d4"];
+const DIM_LABELS = ["Automation", "Memory", "Agent Coverage", "Tools", "Skills", "Workflow"];
+
+const TIER_COLORS: Record<string, string> = {
+  Master: "#f59e0b",
+  Expert: "#f59e0b",
+  Advanced: "#8b5cf6",
+  Intermediate: "#3b82f6",
+  Beginner: "#6b7280",
+};
+
+function radarPoints(scores: number[], cx: number, cy: number, radius: number): string {
+  return scores
+    .map((score, i) => {
+      const angle = (Math.PI * 2 * i) / scores.length - Math.PI / 2;
+      const r = (score / 10) * radius;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      return `${x},${y}`;
+    })
+    .join(" ");
+}
+
+function axisEndpoint(i: number, total: number, cx: number, cy: number, radius: number): { x: number; y: number } {
+  const angle = (Math.PI * 2 * i) / total - Math.PI / 2;
+  return {
+    x: cx + radius * Math.cos(angle),
+    y: cy + radius * Math.sin(angle),
+  };
+}
+
+function labelPosition(i: number, total: number, cx: number, cy: number, radius: number): { x: number; y: number } {
+  const angle = (Math.PI * 2 * i) / total - Math.PI / 2;
+  const r = radius + 28;
+  return {
+    x: cx + r * Math.cos(angle),
+    y: cy + r * Math.sin(angle),
+  };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username } = await params;
+  const profile = getMockProfile(username);
+
+  if (!profile) {
+    return new Response("Profile not found", { status: 404 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const format = searchParams.get("format") ?? "og";
+  const isSquare = format === "square";
+  const width = isSquare ? 1080 : 1200;
+  const height = isSquare ? 1080 : 630;
+
+  const scores = profile.dimensions.map((d) => d.score);
+  const tierColor = TIER_COLORS[profile.tier] ?? "#6b7280";
+
+  // Radar chart geometry
+  const chartCx = isSquare ? 540 : 380;
+  const chartCy = isSquare ? 420 : 315;
+  const chartRadius = isSquare ? 180 : 160;
+
+  const gridLevels = [2, 4, 6, 8, 10];
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width,
+          height,
+          display: "flex",
+          flexDirection: "column",
+          background: "linear-gradient(135deg, #0a0a14 0%, #12121a 50%, #0a0a14 100%)",
+          fontFamily: "system-ui, sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Subtle grid background */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            backgroundImage: "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.03) 1px, transparent 0)",
+            backgroundSize: "40px 40px",
+            display: "flex",
+          }}
+        />
+
+        {isSquare ? (
+          // Square layout: stacked
+          <div style={{ display: "flex", flexDirection: "column", width: "100%", height: "100%", padding: "48px" }}>
+            {/* Header */}
+            <div style={{ display: "flex", alignItems: "center", gap: "20px", marginBottom: "20px" }}>
+              <img
+                src={profile.avatarUrl}
+                width={64}
+                height={64}
+                style={{ borderRadius: "50%", border: "2px solid rgba(255,255,255,0.15)" }}
+              />
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <span style={{ fontSize: 28, fontWeight: 700, color: "white" }}>@{profile.username}</span>
+                <span style={{ fontSize: 16, color: "rgba(255,255,255,0.5)" }}>AgentScore Profile</span>
+              </div>
+            </div>
+
+            {/* Score + Tier */}
+            <div style={{ display: "flex", alignItems: "baseline", gap: "16px", marginBottom: "12px" }}>
+              <span style={{ fontSize: 72, fontWeight: 800, color: tierColor, lineHeight: 1 }}>
+                {profile.composite}
+              </span>
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <span style={{ fontSize: 20, fontWeight: 600, color: tierColor }}>{profile.tier}</span>
+                <span style={{ fontSize: 14, color: "rgba(255,255,255,0.4)" }}>{profile.tierDescription}</span>
+              </div>
+            </div>
+
+            {/* Personality */}
+            <span style={{ fontSize: 15, color: "rgba(255,255,255,0.5)", fontStyle: "italic", marginBottom: "24px", lineHeight: 1.4 }}>
+              &ldquo;{profile.personality}&rdquo;
+            </span>
+
+            {/* Radar Chart (SVG) */}
+            <div style={{ display: "flex", flex: 1, justifyContent: "center", alignItems: "center" }}>
+              <svg width={420} height={420} viewBox="0 0 420 420">
+                {/* Grid */}
+                {gridLevels.map((level) => (
+                  <polygon
+                    key={level}
+                    points={Array.from({ length: 6 }, (_, i) => {
+                      const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                      const r = (level / 10) * 170;
+                      return `${210 + r * Math.cos(angle)},${210 + r * Math.sin(angle)}`;
+                    }).join(" ")}
+                    fill="none"
+                    stroke="rgba(255,255,255,0.08)"
+                    strokeWidth={1}
+                  />
+                ))}
+                {/* Axes */}
+                {Array.from({ length: 6 }, (_, i) => {
+                  const end = axisEndpoint(i, 6, 210, 210, 170);
+                  return <line key={i} x1={210} y1={210} x2={end.x} y2={end.y} stroke="rgba(255,255,255,0.08)" strokeWidth={1} />;
+                })}
+                {/* Data polygon */}
+                <polygon
+                  points={radarPoints(scores, 210, 210, 170)}
+                  fill="rgba(99,102,241,0.15)"
+                  stroke="#6366f1"
+                  strokeWidth={2.5}
+                />
+                {/* Data points */}
+                {scores.map((score, i) => {
+                  const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                  const r = (score / 10) * 170;
+                  return <circle key={i} cx={210 + r * Math.cos(angle)} cy={210 + r * Math.sin(angle)} r={5} fill={DIM_COLORS[i]} />;
+                })}
+                {/* Labels */}
+                {DIM_LABELS.map((label, i) => {
+                  const pos = labelPosition(i, 6, 210, 210, 170);
+                  return (
+                    <text
+                      key={i}
+                      x={pos.x}
+                      y={pos.y}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      fill={DIM_COLORS[i]}
+                      fontSize={12}
+                      fontWeight={600}
+                    >
+                      {label}
+                    </text>
+                  );
+                })}
+              </svg>
+            </div>
+
+            {/* Strengths pills */}
+            <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginTop: "16px" }}>
+              {profile.strengths.slice(0, 3).map((s) => (
+                <span
+                  key={s.dimension}
+                  style={{
+                    padding: "6px 14px",
+                    borderRadius: "20px",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    background: "rgba(99,102,241,0.12)",
+                    color: "#818cf8",
+                    border: "1px solid rgba(99,102,241,0.2)",
+                  }}
+                >
+                  {s.dimension}
+                </span>
+              ))}
+            </div>
+
+            {/* Branding */}
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "20px" }}>
+              <span style={{ fontSize: 14, fontWeight: 700, color: "rgba(255,255,255,0.3)" }}>agentscore.dev</span>
+              <span style={{ fontSize: 12, color: "rgba(255,255,255,0.2)" }}>agentscore.dev/u/{profile.username}</span>
+            </div>
+          </div>
+        ) : (
+          // OG (1200x630) layout: side by side
+          <div style={{ display: "flex", width: "100%", height: "100%", padding: "40px 48px" }}>
+            {/* Left side: info */}
+            <div style={{ display: "flex", flexDirection: "column", width: "440px", justifyContent: "center" }}>
+              {/* Avatar + username */}
+              <div style={{ display: "flex", alignItems: "center", gap: "16px", marginBottom: "20px" }}>
+                <img
+                  src={profile.avatarUrl}
+                  width={52}
+                  height={52}
+                  style={{ borderRadius: "50%", border: "2px solid rgba(255,255,255,0.15)" }}
+                />
+                <span style={{ fontSize: 26, fontWeight: 700, color: "white" }}>@{profile.username}</span>
+              </div>
+
+              {/* Score */}
+              <div style={{ display: "flex", alignItems: "baseline", gap: "12px", marginBottom: "8px" }}>
+                <span style={{ fontSize: 80, fontWeight: 800, color: tierColor, lineHeight: 1 }}>
+                  {profile.composite}
+                </span>
+                <span style={{ fontSize: 24, color: "rgba(255,255,255,0.3)" }}>/10</span>
+              </div>
+
+              {/* Tier */}
+              <span
+                style={{
+                  fontSize: 16,
+                  fontWeight: 600,
+                  color: tierColor,
+                  padding: "4px 12px",
+                  borderRadius: "12px",
+                  background: `${tierColor}18`,
+                  marginBottom: "16px",
+                  display: "flex",
+                  width: "fit-content",
+                }}
+              >
+                {profile.tier} — {profile.tierDescription}
+              </span>
+
+              {/* Personality */}
+              <span style={{ fontSize: 14, color: "rgba(255,255,255,0.45)", fontStyle: "italic", lineHeight: 1.5, marginBottom: "20px" }}>
+                &ldquo;{profile.personality}&rdquo;
+              </span>
+
+              {/* Strength pills */}
+              <div style={{ display: "flex", gap: "6px", flexWrap: "wrap" }}>
+                {profile.strengths.slice(0, 3).map((s) => (
+                  <span
+                    key={s.dimension}
+                    style={{
+                      padding: "5px 12px",
+                      borderRadius: "16px",
+                      fontSize: 12,
+                      fontWeight: 600,
+                      background: "rgba(99,102,241,0.12)",
+                      color: "#818cf8",
+                      border: "1px solid rgba(99,102,241,0.2)",
+                    }}
+                  >
+                    {s.dimension}
+                  </span>
+                ))}
+              </div>
+
+              {/* Branding */}
+              <div style={{ display: "flex", marginTop: "auto", paddingTop: "16px" }}>
+                <span style={{ fontSize: 14, fontWeight: 700, color: "rgba(255,255,255,0.25)" }}>agentscore.dev</span>
+              </div>
+            </div>
+
+            {/* Right side: radar chart */}
+            <div style={{ display: "flex", flex: 1, justifyContent: "center", alignItems: "center" }}>
+              <svg width={440} height={440} viewBox="0 0 440 440">
+                {/* Grid */}
+                {gridLevels.map((level) => (
+                  <polygon
+                    key={level}
+                    points={Array.from({ length: 6 }, (_, i) => {
+                      const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                      const r = (level / 10) * 170;
+                      return `${220 + r * Math.cos(angle)},${220 + r * Math.sin(angle)}`;
+                    }).join(" ")}
+                    fill="none"
+                    stroke="rgba(255,255,255,0.08)"
+                    strokeWidth={1}
+                  />
+                ))}
+                {/* Axes */}
+                {Array.from({ length: 6 }, (_, i) => {
+                  const end = axisEndpoint(i, 6, 220, 220, 170);
+                  return <line key={i} x1={220} y1={220} x2={end.x} y2={end.y} stroke="rgba(255,255,255,0.08)" strokeWidth={1} />;
+                })}
+                {/* Data polygon */}
+                <polygon
+                  points={radarPoints(scores, 220, 220, 170)}
+                  fill="rgba(99,102,241,0.15)"
+                  stroke="#6366f1"
+                  strokeWidth={2.5}
+                />
+                {/* Data points */}
+                {scores.map((score, i) => {
+                  const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                  const r = (score / 10) * 170;
+                  return <circle key={i} cx={220 + r * Math.cos(angle)} cy={220 + r * Math.sin(angle)} r={5} fill={DIM_COLORS[i]} />;
+                })}
+                {/* Labels */}
+                {DIM_LABELS.map((label, i) => {
+                  const pos = labelPosition(i, 6, 220, 220, 170);
+                  return (
+                    <text
+                      key={i}
+                      x={pos.x}
+                      y={pos.y}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      fill={DIM_COLORS[i]}
+                      fontSize={12}
+                      fontWeight={600}
+                    >
+                      {label}
+                    </text>
+                  );
+                })}
+              </svg>
+            </div>
+          </div>
+        )}
+      </div>
+    ),
+    {
+      width,
+      height,
+    }
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
+import type { Metadata } from "next";
 import {
   CheckCircle2,
   AlertTriangle,
@@ -12,11 +13,42 @@ import RadarChart from "@/components/RadarChart";
 import ShareButton from "@/components/ShareButton";
 import FullReport from "@/components/FullReport";
 import LevelUp from "@/components/LevelUp";
+import DownloadInfographic from "@/components/DownloadInfographic";
 import { getMockProfile } from "@/lib/mock-profiles";
 import type { MockDimensionScore } from "@/lib/mock-profiles";
 
 interface ProfilePageProps {
   params: Promise<{ username: string }>;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://agentscore.dev";
+
+export async function generateMetadata({ params }: ProfilePageProps): Promise<Metadata> {
+  const { username } = await params;
+  const profile = getMockProfile(username);
+  if (!profile) return { title: "Profile not found" };
+
+  const ogUrl = `${BASE_URL}/api/og/${username}`;
+  const title = `@${username} — AgentScore ${profile.composite} (${profile.tier})`;
+  const description = profile.personality;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "profile",
+      url: `${BASE_URL}/u/${username}`,
+      images: [{ url: ogUrl, width: 1200, height: 630, alt: `AgentScore for @${username}` }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogUrl],
+    },
+  };
 }
 
 const TIER_COLORS: Record<string, string> = {
@@ -161,6 +193,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
               </div>
               <div className="mt-4 flex items-center justify-center gap-3">
                 <ShareButton username={profile.username} />
+                <DownloadInfographic username={profile.username} />
               </div>
             </div>
           </div>

--- a/src/components/DownloadInfographic.tsx
+++ b/src/components/DownloadInfographic.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+
+interface DownloadInfographicProps {
+  username: string;
+}
+
+export default function DownloadInfographic({ username }: DownloadInfographicProps) {
+  const [loading, setLoading] = useState(false);
+  const [format, setFormat] = useState<"og" | "square">("og");
+
+  const handleDownload = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/og/${username}?format=${format}`);
+      if (!res.ok) throw new Error("Failed to generate image");
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `agentscore-${username}-${format === "og" ? "1200x630" : "1080x1080"}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      // download failed
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <select
+        value={format}
+        onChange={(e) => setFormat(e.target.value as "og" | "square")}
+        className="rounded px-2 py-1 text-xs bg-white/5 border border-white/10 text-white/60 focus:outline-none"
+      >
+        <option value="og">1200x630</option>
+        <option value="square">1080x1080</option>
+      </select>
+      <button
+        onClick={handleDownload}
+        disabled={loading}
+        className="flex items-center gap-1 rounded px-2 py-1 text-xs text-white/60 hover:text-white hover:bg-white/10 transition-colors disabled:opacity-50"
+      >
+        {loading ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <Download size={13} />
+        )}
+        <span>Download</span>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/api/og/[username]` edge endpoint generates infographic via @vercel/og (Satori)
- Two formats: `?format=og` (1200x630, default) and `?format=square` (1080x1080)
- Raw SVG radar chart with hexagonal grid, color-coded dimension points
- Profile page gets OG/Twitter meta tags and a "Download infographic" button
- Dark gradient background, avatar, score, tier, personality, strength pills, branding

Closes #12

## Test plan
- [ ] Visit `/api/og/wkliwk` — verify 1200x630 PNG with radar chart renders
- [ ] Visit `/api/og/wkliwk?format=square` — verify 1080x1080 square format
- [ ] Visit `/api/og/minimal_maya` — verify beginner profile renders correctly
- [ ] Visit `/api/og/nonexistent` — verify 404 response
- [ ] Profile page `/u/wkliwk` — verify OG meta tags in page source
- [ ] Profile page — click download button with both format options
- [ ] Share profile URL in Slack/Discord/Twitter preview — verify card image appears
- [ ] TypeScript: `npx tsc --noEmit` passes
- [ ] Tests: `npx vitest run` — 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)