### PR TITLE
feat: benchmark task grader — paste-and-grade flow

### DIFF
--- a/src/app/api/benchmarks/grade/route.ts
+++ b/src/app/api/benchmarks/grade/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { gradeBenchmark } from "@/lib/benchmark/grader";
+import { BENCHMARK_TASKS } from "@/lib/benchmark/tasks";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { username, submissions } = body as {
+      username?: string;
+      submissions?: Record<string, Record<string, string>>;
+    };
+
+    if (!username || typeof username !== "string" || username.trim().length === 0) {
+      return NextResponse.json(
+        { error: "username is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!submissions || typeof submissions !== "object") {
+      return NextResponse.json(
+        { error: "submissions object is required" },
+        { status: 400 }
+      );
+    }
+
+    // Validate that submission keys are valid task IDs
+    const validIds = new Set(BENCHMARK_TASKS.map((t) => t.id));
+    const invalidKeys = Object.keys(submissions).filter((k) => !validIds.has(k));
+    if (invalidKeys.length > 0) {
+      return NextResponse.json(
+        { error: `Unknown task IDs: ${invalidKeys.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const result = gradeBenchmark(username.trim(), submissions);
+
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+}
+
+export async function GET() {
+  // Return task definitions (without rubric check functions)
+  const tasks = BENCHMARK_TASKS.map((t) => ({
+    id: t.id,
+    title: t.title,
+    description: t.description,
+    prompt: t.prompt,
+    outputTemplate: t.outputTemplate,
+    checkCount: t.rubric.length,
+    checks: t.rubric.map((r) => ({ id: r.id, description: r.description })),
+  }));
+
+  return NextResponse.json({ tasks });
+}

--- a/src/app/benchmark/page.tsx
+++ b/src/app/benchmark/page.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  ClipboardCheck,
+  Copy,
+  Check,
+  ChevronRight,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+  Play,
+} from "lucide-react";
+import Navbar from "@/components/Navbar";
+import type { BenchmarkResult } from "@/lib/benchmark/types";
+
+interface TaskDef {
+  id: string;
+  title: string;
+  description: string;
+  prompt: string;
+  outputTemplate: string;
+  checkCount: number;
+  checks: { id: string; description: string }[];
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* */
+    }
+  };
+  return (
+    <button
+      onClick={handleCopy}
+      className="text-white/30 hover:text-white transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? (
+        <Check size={14} className="text-emerald-400" />
+      ) : (
+        <Copy size={14} />
+      )}
+    </button>
+  );
+}
+
+export default function BenchmarkPage() {
+  const [tasks, setTasks] = useState<TaskDef[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [username, setUsername] = useState("");
+  const [outputs, setOutputs] = useState<Record<string, string>>({});
+  const [result, setResult] = useState<BenchmarkResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [grading, setGrading] = useState(false);
+  const [expandedTask, setExpandedTask] = useState<string | null>(null);
+
+  const loadTasks = useCallback(async () => {
+    try {
+      const res = await fetch("/api/benchmarks/grade");
+      const data = await res.json();
+      setTasks(data.tasks);
+      setLoaded(true);
+      // Initialize outputs
+      const init: Record<string, string> = {};
+      for (const t of data.tasks) {
+        init[t.id] = t.outputTemplate;
+      }
+      setOutputs(init);
+    } catch {
+      setError("Failed to load benchmark tasks");
+    }
+  }, []);
+
+  const handleGrade = useCallback(async () => {
+    setError(null);
+    setResult(null);
+
+    if (!username.trim()) {
+      setError("Please enter your GitHub username");
+      return;
+    }
+
+    // Parse each output as JSON
+    const submissions: Record<string, Record<string, string>> = {};
+    for (const task of tasks) {
+      const raw = outputs[task.id];
+      if (!raw || raw === task.outputTemplate) continue;
+      try {
+        submissions[task.id] = JSON.parse(raw);
+      } catch {
+        setError(`Invalid JSON in "${task.title}" output. Please check the format.`);
+        return;
+      }
+    }
+
+    if (Object.keys(submissions).length === 0) {
+      setError("Please fill in at least one task output before grading.");
+      return;
+    }
+
+    setGrading(true);
+    try {
+      const res = await fetch("/api/benchmarks/grade", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: username.trim(), submissions }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Grading failed");
+        return;
+      }
+      setResult(data);
+    } catch {
+      setError("Failed to submit for grading");
+    } finally {
+      setGrading(false);
+    }
+  }, [username, tasks, outputs]);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1 px-4 py-10 md:py-14">
+        <div className="mx-auto max-w-3xl">
+          <div className="flex items-center gap-3 mb-2">
+            <ClipboardCheck size={24} className="text-cyan-400" />
+            <h1 className="text-2xl font-bold text-white">
+              Benchmark Your Setup
+            </h1>
+          </div>
+          <p className="text-sm text-white/50 mb-8">
+            Run standardized tasks in your Claude Code session, paste the
+            structured output here, and get graded instantly. No AI
+            grading — all checks are deterministic.
+          </p>
+
+          {/* How it works */}
+          <div className="rounded-xl bg-[#12121a] border border-cyan-500/20 p-5 mb-8">
+            <h2 className="text-xs uppercase tracking-widest text-cyan-400 mb-3">
+              How it works
+            </h2>
+            <ol className="space-y-2 text-sm text-white/60">
+              <li className="flex items-start gap-2">
+                <span className="font-mono text-cyan-400 shrink-0">1.</span>
+                Load the tasks below and copy each prompt into your Claude Code
+                session
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="font-mono text-cyan-400 shrink-0">2.</span>
+                After CC completes each task, fill in the output template with
+                what happened
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="font-mono text-cyan-400 shrink-0">3.</span>
+                Click &quot;Grade My Results&quot; to see your benchmark score
+              </li>
+            </ol>
+          </div>
+
+          {!loaded ? (
+            <button
+              onClick={loadTasks}
+              className="flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-medium bg-cyan-600 text-white hover:bg-cyan-500 transition-colors"
+            >
+              <Play size={16} />
+              Load Benchmark Tasks
+            </button>
+          ) : (
+            <>
+              {/* Username input */}
+              <div className="mb-8">
+                <label className="block text-xs uppercase tracking-widest text-white/40 mb-2">
+                  GitHub Username
+                </label>
+                <input
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="your-github-username"
+                  className="w-full max-w-xs rounded-lg bg-[#12121a] border border-white/10 px-4 py-2.5 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-cyan-500/50"
+                />
+              </div>
+
+              {/* Tasks */}
+              <div className="space-y-4 mb-8">
+                {tasks.map((task, i) => {
+                  const isExpanded = expandedTask === task.id;
+                  const taskResult = result?.tasks.find(
+                    (t) => t.taskId === task.id
+                  );
+                  return (
+                    <div
+                      key={task.id}
+                      className="rounded-xl bg-[#12121a] border border-white/10 overflow-hidden"
+                    >
+                      {/* Task header */}
+                      <button
+                        onClick={() =>
+                          setExpandedTask(isExpanded ? null : task.id)
+                        }
+                        className="w-full flex items-center gap-3 p-4 text-left hover:bg-white/[0.02] transition-colors"
+                      >
+                        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-cyan-500/15 text-xs font-bold text-cyan-400">
+                          {i + 1}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-semibold text-white text-sm">
+                              {task.title}
+                            </span>
+                            {taskResult && (
+                              <span
+                                className={`rounded px-1.5 py-0.5 text-xs font-mono ${
+                                  taskResult.passed
+                                    ? "bg-emerald-500/10 text-emerald-400"
+                                    : "bg-red-500/10 text-red-400"
+                                }`}
+                              >
+                                {taskResult.passed ? "PASS" : "FAIL"}
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-white/40 truncate">
+                            {task.description}
+                          </p>
+                        </div>
+                        <ChevronRight
+                          size={16}
+                          className={`text-white/30 transition-transform ${
+                            isExpanded ? "rotate-90" : ""
+                          }`}
+                        />
+                      </button>
+
+                      {/* Expanded content */}
+                      {isExpanded && (
+                        <div className="border-t border-white/5 p-4 space-y-4">
+                          {/* Prompt */}
+                          <div>
+                            <div className="flex items-center justify-between mb-2">
+                              <span className="text-xs uppercase tracking-widest text-white/40">
+                                Prompt (copy into CC)
+                              </span>
+                              <CopyButton text={task.prompt} />
+                            </div>
+                            <pre className="rounded-lg bg-black/40 p-3 text-xs text-white/70 whitespace-pre-wrap font-mono">
+                              {task.prompt}
+                            </pre>
+                          </div>
+
+                          {/* Rubric checks */}
+                          <div>
+                            <span className="text-xs uppercase tracking-widest text-white/40 mb-2 block">
+                              Grading Criteria
+                            </span>
+                            <ul className="space-y-1">
+                              {task.checks.map((c) => {
+                                const cr = taskResult?.checks.find(
+                                  (ch) => ch.checkId === c.id
+                                );
+                                return (
+                                  <li
+                                    key={c.id}
+                                    className="flex items-center gap-2 text-xs"
+                                  >
+                                    {cr ? (
+                                      cr.passed ? (
+                                        <CheckCircle2
+                                          size={13}
+                                          className="shrink-0 text-emerald-500"
+                                        />
+                                      ) : (
+                                        <XCircle
+                                          size={13}
+                                          className="shrink-0 text-red-400"
+                                        />
+                                      )
+                                    ) : (
+                                      <span className="h-3.5 w-3.5 shrink-0 rounded-full border border-white/20" />
+                                    )}
+                                    <span
+                                      className={
+                                        cr
+                                          ? cr.passed
+                                            ? "text-white/70"
+                                            : "text-red-300"
+                                          : "text-white/50"
+                                      }
+                                    >
+                                      {c.description}
+                                    </span>
+                                    {cr && !cr.passed && cr.reason && (
+                                      <span className="text-red-400/60 ml-1">
+                                        — {cr.reason}
+                                      </span>
+                                    )}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          </div>
+
+                          {/* Output template */}
+                          <div>
+                            <span className="text-xs uppercase tracking-widest text-white/40 mb-2 block">
+                              Your Output (fill in after running)
+                            </span>
+                            <textarea
+                              value={outputs[task.id] ?? ""}
+                              onChange={(e) =>
+                                setOutputs((prev) => ({
+                                  ...prev,
+                                  [task.id]: e.target.value,
+                                }))
+                              }
+                              className="w-full h-32 rounded-lg bg-black/40 border border-white/10 p-3 font-mono text-xs text-white/80 placeholder:text-white/20 resize-y focus:outline-none focus:border-cyan-500/50"
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Grade button */}
+              <button
+                onClick={handleGrade}
+                disabled={grading}
+                className="flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-medium bg-cyan-600 text-white hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors mb-8"
+              >
+                <ClipboardCheck size={16} />
+                {grading ? "Grading..." : "Grade My Results"}
+              </button>
+
+              {/* Error */}
+              {error && (
+                <div className="flex items-start gap-3 rounded-xl bg-red-500/10 border border-red-500/20 p-4 mb-8">
+                  <AlertCircle
+                    size={18}
+                    className="text-red-400 shrink-0 mt-0.5"
+                  />
+                  <p className="text-sm text-red-300">{error}</p>
+                </div>
+              )}
+
+              {/* Results */}
+              {result && (
+                <div className="rounded-xl bg-[#12121a] border border-white/10 p-6">
+                  <div className="flex items-center gap-3 mb-6">
+                    <ClipboardCheck size={20} className="text-cyan-400" />
+                    <h2 className="text-lg font-semibold text-white">
+                      Benchmark Results
+                    </h2>
+                  </div>
+
+                  {/* Score */}
+                  <div className="text-center mb-6">
+                    <div
+                      className={`text-5xl font-bold ${
+                        result.score >= 80
+                          ? "text-emerald-400"
+                          : result.score >= 50
+                            ? "text-amber-400"
+                            : "text-red-400"
+                      }`}
+                    >
+                      {result.score}%
+                    </div>
+                    <p className="text-sm text-white/40 mt-1">
+                      {result.passedTasks} of {result.totalTasks} tasks passed
+                    </p>
+                  </div>
+
+                  {/* Per-task results */}
+                  <div className="space-y-2">
+                    {result.tasks.map((tr) => {
+                      const task = tasks.find((t) => t.id === tr.taskId);
+                      return (
+                        <div
+                          key={tr.taskId}
+                          className="flex items-center gap-3 rounded-lg bg-white/[0.02] p-3"
+                        >
+                          {tr.passed ? (
+                            <CheckCircle2
+                              size={16}
+                              className="text-emerald-500 shrink-0"
+                            />
+                          ) : (
+                            <XCircle
+                              size={16}
+                              className="text-red-400 shrink-0"
+                            />
+                          )}
+                          <span className="flex-1 text-sm text-white/70">
+                            {task?.title ?? tr.taskId}
+                          </span>
+                          <span
+                            className={`text-xs font-mono ${
+                              tr.passed ? "text-emerald-400" : "text-red-400"
+                            }`}
+                          >
+                            {tr.checks.filter((c) => c.passed).length}/
+                            {tr.checks.length}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <p className="text-xs text-white/30 text-center mt-6">
+                    Benchmark score is separate from your AgentScore config
+                    score.
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   ArrowUpRight,
   GitFork,
+  ClipboardCheck,
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
 import RadarChart from "@/components/RadarChart";
@@ -351,6 +352,27 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                 <DimensionCard key={dim.dimension} dim={dim} />
               ))}
             </div>
+          </div>
+
+          {/* Benchmark CTA */}
+          <div className="rounded-xl bg-[#12121a] border border-cyan-500/20 p-6 mb-10">
+            <div className="flex items-center gap-3 mb-3">
+              <ClipboardCheck size={20} className="text-cyan-400" />
+              <h2 className="text-lg font-semibold text-white">
+                Benchmark Your Setup
+              </h2>
+            </div>
+            <p className="text-sm text-white/50 mb-4">
+              Config scoring tells you what you have — benchmarking tells you if
+              it works. Run 6 standardized tasks and get graded.
+            </p>
+            <Link
+              href="/benchmark"
+              className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium bg-cyan-600 text-white hover:bg-cyan-500 transition-colors"
+            >
+              <ClipboardCheck size={14} />
+              Take the Benchmark
+            </Link>
           </div>
 
           {/* Manifest Overview */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,6 +18,12 @@ export default function Navbar() {
             Explore
           </Link>
           <Link
+            href="/benchmark"
+            className="text-sm text-white/70 hover:text-white transition-colors hidden sm:inline"
+          >
+            Benchmark
+          </Link>
+          <Link
             href="https://github.com/wkliwk/agent-score"
             target="_blank"
             rel="noopener noreferrer"

--- a/src/lib/benchmark/__tests__/grader.test.ts
+++ b/src/lib/benchmark/__tests__/grader.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { gradeBenchmark } from "../grader";
+import { BENCHMARK_TASKS } from "../tasks";
+
+describe("gradeBenchmark", () => {
+  it("returns all tasks with fail when no submissions provided", () => {
+    const result = gradeBenchmark("testuser", {});
+    expect(result.username).toBe("testuser");
+    expect(result.totalTasks).toBe(BENCHMARK_TASKS.length);
+    expect(result.passedTasks).toBe(0);
+    expect(result.score).toBe(0);
+    expect(result.tasks).toHaveLength(BENCHMARK_TASKS.length);
+    for (const task of result.tasks) {
+      expect(task.passed).toBe(false);
+    }
+  });
+
+  it("passes file-creation task with correct output", () => {
+    const result = gradeBenchmark("testuser", {
+      "file-creation": {
+        tool_used: "Write",
+        file_path: "/tmp/agentscore-test.txt",
+        file_content: "Hello from AgentScore benchmark",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "file-creation");
+    expect(task?.passed).toBe(true);
+    expect(task?.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it("fails file-creation task when wrong tool used", () => {
+    const result = gradeBenchmark("testuser", {
+      "file-creation": {
+        tool_used: "Bash",
+        file_path: "/tmp/agentscore-test.txt",
+        file_content: "Hello from AgentScore benchmark",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "file-creation");
+    expect(task?.passed).toBe(false);
+    const toolCheck = task?.checks.find((c) => c.checkId === "correct-tool");
+    expect(toolCheck?.passed).toBe(false);
+  });
+
+  it("passes file-read task with correct output", () => {
+    const result = gradeBenchmark("testuser", {
+      "file-read": {
+        tool_used: "Read",
+        file_content: "Hello from AgentScore benchmark",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "file-read");
+    expect(task?.passed).toBe(true);
+  });
+
+  it("passes bash-execution task with correct output", () => {
+    const result = gradeBenchmark("testuser", {
+      "bash-execution": {
+        tool_used: "Bash",
+        command_output: "11",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "bash-execution");
+    expect(task?.passed).toBe(true);
+  });
+
+  it("passes multi-step task with correct output", () => {
+    const result = gradeBenchmark("testuser", {
+      "multi-step": {
+        tools_used: "Read, Write",
+        word_count: "5",
+        output_path: "/tmp/agentscore-wordcount.txt",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "multi-step");
+    expect(task?.passed).toBe(true);
+  });
+
+  it("passes error-handling task with correct output", () => {
+    const result = gradeBenchmark("testuser", {
+      "error-handling": {
+        tool_used: "Read",
+        error_occurred: "yes",
+        hallucinated_content: "no",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "error-handling");
+    expect(task?.passed).toBe(true);
+  });
+
+  it("passes git-task with correct output", () => {
+    const result = gradeBenchmark("testuser", {
+      "git-task": {
+        tool_used: "Bash",
+        branch_name: "main",
+        has_uncommitted_changes: "no",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "git-task");
+    expect(task?.passed).toBe(true);
+  });
+
+  it("calculates correct score when all tasks pass", () => {
+    const result = gradeBenchmark("testuser", {
+      "file-creation": {
+        tool_used: "Write",
+        file_path: "/tmp/agentscore-test.txt",
+        file_content: "Hello from AgentScore benchmark",
+      },
+      "file-read": {
+        tool_used: "Read",
+        file_content: "Hello from AgentScore benchmark",
+      },
+      "bash-execution": {
+        tool_used: "Bash",
+        command_output: "11",
+      },
+      "multi-step": {
+        tools_used: "Read, Write",
+        word_count: "5",
+        output_path: "/tmp/agentscore-wordcount.txt",
+      },
+      "error-handling": {
+        tool_used: "Read",
+        error_occurred: "yes",
+        hallucinated_content: "no",
+      },
+      "git-task": {
+        tool_used: "Bash",
+        branch_name: "main",
+        has_uncommitted_changes: "no",
+      },
+    });
+    expect(result.passedTasks).toBe(6);
+    expect(result.score).toBe(100);
+  });
+
+  it("calculates partial score correctly", () => {
+    const result = gradeBenchmark("testuser", {
+      "file-creation": {
+        tool_used: "Write",
+        file_path: "/tmp/agentscore-test.txt",
+        file_content: "Hello from AgentScore benchmark",
+      },
+      "file-read": {
+        tool_used: "Read",
+        file_content: "Hello from AgentScore benchmark",
+      },
+      "bash-execution": {
+        tool_used: "Bash",
+        command_output: "11",
+      },
+    });
+    // 3 passed out of 6 total = 50%
+    expect(result.passedTasks).toBe(3);
+    expect(result.score).toBe(50);
+  });
+
+  it("generates valid id and timestamp", () => {
+    const result = gradeBenchmark("testuser", {});
+    expect(result.id).toBeTruthy();
+    expect(result.submittedAt).toBeTruthy();
+    expect(new Date(result.submittedAt).getTime()).not.toBeNaN();
+  });
+
+  it("is case-insensitive for tool names", () => {
+    const result = gradeBenchmark("testuser", {
+      "file-creation": {
+        tool_used: "write",
+        file_path: "/tmp/agentscore-test.txt",
+        file_content: "Hello from AgentScore benchmark",
+      },
+    });
+    const task = result.tasks.find((t) => t.taskId === "file-creation");
+    expect(task?.passed).toBe(true);
+  });
+});

--- a/src/lib/benchmark/grader.ts
+++ b/src/lib/benchmark/grader.ts
@@ -1,0 +1,54 @@
+import type { BenchmarkResult, TaskResult, CheckResult } from "./types";
+import { BENCHMARK_TASKS } from "./tasks";
+
+/**
+ * Grade a set of benchmark task outputs against the rubric.
+ * Each task output is a key-value record parsed from the user's JSON submission.
+ */
+export function gradeBenchmark(
+  username: string,
+  submissions: Record<string, Record<string, string>>
+): BenchmarkResult {
+  const tasks: TaskResult[] = BENCHMARK_TASKS.map((task) => {
+    const output = submissions[task.id] ?? {};
+    const checks: CheckResult[] = task.rubric.map((rubricCheck) => {
+      let passed = false;
+      let reason: string | undefined;
+      try {
+        passed = rubricCheck.check(output);
+        if (!passed) {
+          reason = `Expected check "${rubricCheck.description}" to pass`;
+        }
+      } catch {
+        passed = false;
+        reason = "Check threw an error during evaluation";
+      }
+      return {
+        checkId: rubricCheck.id,
+        description: rubricCheck.description,
+        passed,
+        reason: passed ? undefined : reason,
+      };
+    });
+
+    return {
+      taskId: task.id,
+      passed: checks.every((c) => c.passed),
+      checks,
+    };
+  });
+
+  const passedTasks = tasks.filter((t) => t.passed).length;
+  const totalTasks = tasks.length;
+  const score = totalTasks > 0 ? Math.round((passedTasks / totalTasks) * 100) : 0;
+
+  return {
+    id: crypto.randomUUID(),
+    username,
+    score,
+    totalTasks,
+    passedTasks,
+    tasks,
+    submittedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/benchmark/tasks.ts
+++ b/src/lib/benchmark/tasks.ts
@@ -1,0 +1,243 @@
+import type { BenchmarkTask } from "./types";
+
+export const BENCHMARK_TASKS: BenchmarkTask[] = [
+  {
+    id: "file-creation",
+    title: "File Creation",
+    description:
+      "Create a file at a specific path with exact content. Tests whether CC uses the Write tool correctly.",
+    prompt: `Create a file at /tmp/agentscore-test.txt with exactly this content (no extra whitespace or newlines):
+Hello from AgentScore benchmark
+
+After creating the file, report what you did.`,
+    outputTemplate: JSON.stringify(
+      {
+        tool_used: "<Write or Bash or other>",
+        file_path: "</tmp/agentscore-test.txt or other>",
+        file_content: "<paste the content you wrote>",
+      },
+      null,
+      2
+    ),
+    rubric: [
+      {
+        id: "correct-tool",
+        description: "Used the Write tool (not Bash with echo/cat)",
+        check: (output) => {
+          const tool = (output.tool_used ?? "").toLowerCase().trim();
+          return tool === "write";
+        },
+      },
+      {
+        id: "correct-path",
+        description: "File path is /tmp/agentscore-test.txt",
+        check: (output) =>
+          (output.file_path ?? "").trim() === "/tmp/agentscore-test.txt",
+      },
+      {
+        id: "correct-content",
+        description: "File content matches exactly",
+        check: (output) =>
+          (output.file_content ?? "").trim() ===
+          "Hello from AgentScore benchmark",
+      },
+    ],
+  },
+  {
+    id: "file-read",
+    title: "File Read + Extract",
+    description:
+      "Read a fixture and extract a specific value. Tests Read tool usage and comprehension.",
+    prompt: `Read the file /tmp/agentscore-test.txt that was created in the previous task. What is the exact content of that file? Report the tool you used and the content.`,
+    outputTemplate: JSON.stringify(
+      {
+        tool_used: "<Read or Bash or other>",
+        file_content: "<exact content of the file>",
+      },
+      null,
+      2
+    ),
+    rubric: [
+      {
+        id: "correct-tool",
+        description: "Used the Read tool (not Bash with cat/head/tail)",
+        check: (output) => {
+          const tool = (output.tool_used ?? "").toLowerCase().trim();
+          return tool === "read";
+        },
+      },
+      {
+        id: "correct-content",
+        description: "Extracted correct file content",
+        check: (output) =>
+          (output.file_content ?? "").trim() ===
+          "Hello from AgentScore benchmark",
+      },
+    ],
+  },
+  {
+    id: "bash-execution",
+    title: "Bash Execution",
+    description:
+      "Run a deterministic shell command and report the output. Tests Bash tool usage.",
+    prompt: `Run this exact shell command and report the output:
+echo "AgentScore" | wc -c
+
+Report the tool used and the exact numeric output.`,
+    outputTemplate: JSON.stringify(
+      {
+        tool_used: "<Bash or other>",
+        command_output: "<the number output by wc -c>",
+      },
+      null,
+      2
+    ),
+    rubric: [
+      {
+        id: "correct-tool",
+        description: "Used the Bash tool",
+        check: (output) => {
+          const tool = (output.tool_used ?? "").toLowerCase().trim();
+          return tool === "bash";
+        },
+      },
+      {
+        id: "correct-output",
+        description: "Output is 11 (10 chars + newline)",
+        check: (output) => {
+          const val = (output.command_output ?? "").trim();
+          return val === "11";
+        },
+      },
+    ],
+  },
+  {
+    id: "multi-step",
+    title: "Multi-Step Handoff",
+    description:
+      "Read a value from one file, transform it, write to another. Tests tool chaining.",
+    prompt: `1. Read /tmp/agentscore-test.txt
+2. Count the number of words in the content
+3. Write the word count (just the number) to /tmp/agentscore-wordcount.txt
+
+Report all tools used in order and the word count.`,
+    outputTemplate: JSON.stringify(
+      {
+        tools_used: "<comma-separated list of tools in order>",
+        word_count: "<the number you wrote>",
+        output_path: "</tmp/agentscore-wordcount.txt or other>",
+      },
+      null,
+      2
+    ),
+    rubric: [
+      {
+        id: "used-read",
+        description: "Used Read tool as first step",
+        check: (output) => {
+          const tools = (output.tools_used ?? "").toLowerCase();
+          return tools.includes("read");
+        },
+      },
+      {
+        id: "used-write",
+        description: "Used Write tool for output",
+        check: (output) => {
+          const tools = (output.tools_used ?? "").toLowerCase();
+          return tools.includes("write");
+        },
+      },
+      {
+        id: "correct-count",
+        description: "Word count is 5",
+        check: (output) => (output.word_count ?? "").trim() === "5",
+      },
+      {
+        id: "correct-path",
+        description: "Output written to /tmp/agentscore-wordcount.txt",
+        check: (output) =>
+          (output.output_path ?? "").trim() ===
+          "/tmp/agentscore-wordcount.txt",
+      },
+    ],
+  },
+  {
+    id: "error-handling",
+    title: "Error Handling",
+    description:
+      "Read a file that does not exist. Tests graceful error handling without hallucination.",
+    prompt: `Read the file /tmp/agentscore-nonexistent-file-xyz.txt
+
+This file does not exist. Report what happened.`,
+    outputTemplate: JSON.stringify(
+      {
+        tool_used: "<Read or other>",
+        error_occurred: "<yes or no>",
+        hallucinated_content: "<yes or no — did you make up file content?>",
+      },
+      null,
+      2
+    ),
+    rubric: [
+      {
+        id: "correct-tool",
+        description: "Used the Read tool to attempt reading",
+        check: (output) => {
+          const tool = (output.tool_used ?? "").toLowerCase().trim();
+          return tool === "read";
+        },
+      },
+      {
+        id: "reported-error",
+        description: "Correctly reported that an error occurred",
+        check: (output) =>
+          (output.error_occurred ?? "").toLowerCase().trim() === "yes",
+      },
+      {
+        id: "no-hallucination",
+        description: "Did not hallucinate file content",
+        check: (output) =>
+          (output.hallucinated_content ?? "").toLowerCase().trim() === "no",
+      },
+    ],
+  },
+  {
+    id: "git-task",
+    title: "Git Status",
+    description:
+      "Run git status and report the output. Tests Bash usage for git operations.",
+    prompt: `Run "git status" in your current working directory and report the output. Include the branch name and whether there are uncommitted changes.`,
+    outputTemplate: JSON.stringify(
+      {
+        tool_used: "<Bash or other>",
+        branch_name: "<current branch name>",
+        has_uncommitted_changes: "<yes or no>",
+      },
+      null,
+      2
+    ),
+    rubric: [
+      {
+        id: "correct-tool",
+        description: "Used the Bash tool",
+        check: (output) => {
+          const tool = (output.tool_used ?? "").toLowerCase().trim();
+          return tool === "bash";
+        },
+      },
+      {
+        id: "has-branch",
+        description: "Reported a branch name (non-empty)",
+        check: (output) => (output.branch_name ?? "").trim().length > 0,
+      },
+      {
+        id: "has-status",
+        description: "Reported uncommitted changes status",
+        check: (output) => {
+          const val = (output.has_uncommitted_changes ?? "").toLowerCase().trim();
+          return val === "yes" || val === "no";
+        },
+      },
+    ],
+  },
+];

--- a/src/lib/benchmark/types.ts
+++ b/src/lib/benchmark/types.ts
@@ -1,0 +1,37 @@
+export interface BenchmarkTask {
+  id: string;
+  title: string;
+  description: string;
+  prompt: string;
+  outputTemplate: string;
+  rubric: RubricCheck[];
+}
+
+export interface RubricCheck {
+  id: string;
+  description: string;
+  check: (output: Record<string, string>) => boolean;
+}
+
+export interface TaskResult {
+  taskId: string;
+  passed: boolean;
+  checks: CheckResult[];
+}
+
+export interface CheckResult {
+  checkId: string;
+  description: string;
+  passed: boolean;
+  reason?: string;
+}
+
+export interface BenchmarkResult {
+  id: string;
+  username: string;
+  score: number;
+  totalTasks: number;
+  passedTasks: number;
+  tasks: TaskResult[];
+  submittedAt: string;
+}


### PR DESCRIPTION
## Summary
- 6 standardized benchmark tasks: file creation, file read, bash execution, multi-step handoff, error handling, git status
- Deterministic rubric grader (no AI) — string match, pattern match, tool name checks
- `/benchmark` page: load tasks, copy prompts, paste JSON output, get instant results
- `POST /api/benchmarks/grade` endpoint + `GET` for task definitions
- Benchmark CTA section on profile page
- Navbar link to benchmark
- 12 unit tests for grader (all passing, 52 total suite)

## Test plan
- [ ] Visit `/benchmark`, load tasks, verify all 6 display correctly
- [ ] Copy a prompt, run in CC, paste output JSON, grade — verify pass/fail
- [ ] Submit with invalid JSON — verify error message
- [ ] Submit with empty form — verify validation
- [ ] Check profile page shows benchmark CTA section
- [ ] Run `npx vitest run` — 52 tests pass

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)