### PR TITLE
feat: npm publish workflow + CLI package metadata

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,35 @@
+name: Publish CLI to npm
+
+on:
+  push:
+    tags:
+      - "cli-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        working-directory: cli
+        run: npm ci
+
+      - name: Build
+        working-directory: cli
+        run: npm run build
+
+      - name: Publish
+        working-directory: cli
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,27 @@
     "prepublishOnly": "npm run build"
   },
   "files": ["dist"],
+  "keywords": [
+    "claude",
+    "claude-code",
+    "agentscore",
+    "ai",
+    "agent",
+    "mcp",
+    "scoring",
+    "cli"
+  ],
+  "author": "wkliwk",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wkliwk/agent-score.git",
+    "directory": "cli"
+  },
+  "homepage": "https://agentscore.dev",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "chalk": "^5.3.0",
     "ora": "^8.0.1",


### PR DESCRIPTION
## Summary
- `.github/workflows/publish-cli.yml` — triggers on `cli-v*` tags, builds + publishes to npm with provenance
- `cli/package.json` — added keywords, author, license (MIT), repository, homepage, engines (>=18)

## How to publish
1. Set `NPM_TOKEN` secret in GitHub repo settings
2. Tag: `git tag cli-v0.1.0 && git push origin cli-v0.1.0`
3. Action runs, publishes `agentscore@0.1.0` to npm
4. Users can then run: `npx agentscore export`

## Test plan
- [ ] CLI builds: `cd cli && npm run build` succeeds
- [ ] `npx tsc --noEmit` — zero errors
- [ ] `npx vitest run` — 112 tests pass
- [ ] After merge + tag: verify npm publish Action runs

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)