### PR TITLE
fix: swap hero CTA button order

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,17 +122,17 @@ export default function HomePage() {
             <Button
               size="lg"
               className="bg-indigo-500 hover:bg-indigo-600 text-white border-0 px-6 h-11"
-              render={<Link href="/explore" />}
+              render={<Link href="/upload" />}
             >
-              Explore profiles
+              Get Your Score
             </Button>
             <Button
               variant="outline"
               size="lg"
               className="border-white/20 text-white hover:bg-white/10 px-6 h-11"
-              render={<Link href="/upload" />}
+              render={<Link href="/explore" />}
             >
-              Upload manifest
+              Explore Profiles
             </Button>
           </div>
 


### PR DESCRIPTION
## What
Swapped the hero section CTA button order so 'Get Your Score' is the primary filled button and 'Explore Profiles' is the secondary outline button.

## Why
Closes #6

The landing page goal is conversion — driving users to run the CLI and get their score. Previously, 'Explore Profiles' was the primary action, which misaligned with this conversion goal.

## Acceptance Criteria
- [x] 'Get Your Score' button is primary (filled indigo)
- [x] 'Explore Profiles' button is secondary (outline)
- [x] Button text updated for clarity
- [x] Links correctly route to /upload and /explore
- [x] TypeScript compiles without errors

## Test Plan
1. Navigate to the landing page (/)
2. Verify the first button reads 'Get Your Score' with filled indigo styling
3. Verify the second button reads 'Explore Profiles' with outline styling
4. Click 'Get Your Score' → should navigate to /upload
5. Click 'Explore Profiles' → should navigate to /explore

🤖 Generated with Claude Code