### PR TITLE
feat(explore): add username search

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { eq, desc, gte, and } from "drizzle-orm";
+import { eq, desc, gte, and, ilike } from "drizzle-orm";
 import { db } from "@/db";
 import { profiles } from "@/db/schema";
 import { scoreManifest } from "@/lib/scoring/engine";
@@ -7,7 +7,6 @@ import { generateReport } from "@/lib/scoring/report";
 import { agentScoreManifestSchema } from "@/lib/validation/manifest.schema";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { auth } from "@/auth";
-import type { ProfileSummary } from "@/lib/types/profile";
 import type { DimensionKey } from "@/lib/scoring/types";
 
 // ---------------------------------------------------------------------------
@@ -135,12 +134,16 @@ export async function GET(request: NextRequest) {
     : undefined;
   const topDimension = searchParams.get("topDimension") as DimensionKey | null;
   const sort = searchParams.get("sort") === "score" ? "score" : "newest";
+  const search = searchParams.get("search")?.trim() ?? "";
 
   const offset = (page - 1) * limit;
 
   const conditions = [eq(profiles.visibility, "public")];
   if (minScore !== undefined && !isNaN(minScore)) {
     conditions.push(gte(profiles.totalScore, minScore));
+  }
+  if (search.length >= 2) {
+    conditions.push(ilike(profiles.githubLogin, `${search}%`));
   }
 
   const whereClause = and(...conditions);
@@ -180,13 +183,14 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  const summaries: ProfileSummary[] = filtered.map((row) => ({
+  const summaries = filtered.map((row) => ({
     id: row.id,
     githubLogin: row.githubLogin,
     displayName: row.displayName,
     avatarUrl: row.avatarUrl ?? null,
     totalScore: row.totalScore ?? null,
     tier: row.tier ?? null,
+    dimensionScores: row.dimensionScores ?? null,
     scoredAt: row.scoredAt?.toISOString() ?? null,
   }));
 

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -4,6 +4,7 @@ import { desc, eq, gte, and, isNotNull, sql } from "drizzle-orm";
 import Navbar from "@/components/Navbar";
 import ProfileCard from "@/components/ProfileCard";
 import ExploreFilters from "@/components/ExploreFilters";
+import ExploreSearch from "@/components/ExploreSearch";
 import { MOCK_PROFILES } from "@/lib/mock-profiles";
 import { dbRowToProfile } from "@/lib/db-to-profile";
 import type { MockProfile } from "@/lib/mock-profiles";
@@ -213,64 +214,67 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
             </p>
           </div>
 
-          {/* Filters */}
-          <ExploreFilters sort={sort} dimension={dimension} />
+          {/* Search + content (search hides default content when active) */}
+          <ExploreSearch>
+            {/* Filters */}
+            <ExploreFilters sort={sort} dimension={dimension} />
 
-          {/* Grid */}
-          {profiles.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-24 text-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/5 mb-4">
-                <Terminal size={24} className="text-white/40" />
+            {/* Grid */}
+            {profiles.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/5 mb-4">
+                  <Terminal size={24} className="text-white/40" />
+                </div>
+                <h2 className="text-lg font-semibold text-white">
+                  Be the first to share your setup
+                </h2>
+                <p className="mt-2 text-sm text-white/50 max-w-xs">
+                  Run{" "}
+                  <code className="font-mono text-emerald-400">
+                    npx agentscore export
+                  </code>{" "}
+                  to generate your profile and join the community.
+                </p>
+                <Link
+                  href="https://github.com/wkliwk/agent-score"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-6 inline-flex items-center gap-2 rounded-lg bg-indigo-500 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-600 transition-colors"
+                >
+                  Get started
+                </Link>
               </div>
-              <h2 className="text-lg font-semibold text-white">
-                Be the first to share your setup
-              </h2>
-              <p className="mt-2 text-sm text-white/50 max-w-xs">
-                Run{" "}
-                <code className="font-mono text-emerald-400">
-                  npx agentscore export
-                </code>{" "}
-                to generate your profile and join the community.
-              </p>
-              <Link
-                href="https://github.com/wkliwk/agent-score"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-6 inline-flex items-center gap-2 rounded-lg bg-indigo-500 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-600 transition-colors"
-              >
-                Get started
-              </Link>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {profiles.map((profile) => (
-                <ProfileCard key={profile.username} profile={profile} />
-              ))}
-            </div>
-          )}
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {profiles.map((profile) => (
+                  <ProfileCard key={profile.username} profile={profile} />
+                ))}
+              </div>
+            )}
 
-          {/* Pagination */}
-          {(page > 1 || hasMore) && (
-            <div className="mt-10 flex items-center justify-center gap-3">
-              {page > 1 && (
-                <Link
-                  href={`/explore?sort=${sort}&dimension=${dimension}&page=${page - 1}`}
-                  className="rounded-lg border border-white/15 bg-[#12121a] px-4 py-2 text-sm text-white/70 hover:text-white hover:border-white/30 transition-colors"
-                >
-                  &larr; Prev
-                </Link>
-              )}
-              <span className="text-sm text-white/40">Page {page}</span>
-              {hasMore && (
-                <Link
-                  href={`/explore?sort=${sort}&dimension=${dimension}&page=${page + 1}`}
-                  className="rounded-lg border border-white/15 bg-[#12121a] px-4 py-2 text-sm text-white/70 hover:text-white hover:border-white/30 transition-colors"
-                >
-                  Next &rarr;
-                </Link>
-              )}
-            </div>
-          )}
+            {/* Pagination */}
+            {(page > 1 || hasMore) && (
+              <div className="mt-10 flex items-center justify-center gap-3">
+                {page > 1 && (
+                  <Link
+                    href={`/explore?sort=${sort}&dimension=${dimension}&page=${page - 1}`}
+                    className="rounded-lg border border-white/15 bg-[#12121a] px-4 py-2 text-sm text-white/70 hover:text-white hover:border-white/30 transition-colors"
+                  >
+                    &larr; Prev
+                  </Link>
+                )}
+                <span className="text-sm text-white/40">Page {page}</span>
+                {hasMore && (
+                  <Link
+                    href={`/explore?sort=${sort}&dimension=${dimension}&page=${page + 1}`}
+                    className="rounded-lg border border-white/15 bg-[#12121a] px-4 py-2 text-sm text-white/70 hover:text-white hover:border-white/30 transition-colors"
+                  >
+                    Next &rarr;
+                  </Link>
+                )}
+              </div>
+            )}
+          </ExploreSearch>
         </div>
       </main>
 

--- a/src/components/ExploreSearch.tsx
+++ b/src/components/ExploreSearch.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback, type ReactNode } from "react";
+import { Search, X } from "lucide-react";
+import ProfileCard from "@/components/ProfileCard";
+import { dbRowToProfile } from "@/lib/db-to-profile";
+import type { MockProfile } from "@/lib/mock-profiles";
+
+interface ProfileApiRow {
+  githubLogin: string;
+  displayName: string;
+  avatarUrl: string | null;
+  totalScore: number | null;
+  tier: string | null;
+  dimensionScores: unknown;
+}
+
+interface ExploreSearchProps {
+  children: ReactNode;
+}
+
+export default function ExploreSearch({ children }: ExploreSearchProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<MockProfile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchResults = useCallback(async (q: string) => {
+    if (q.length < 2) {
+      setResults([]);
+      setSearched(false);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setSearched(true);
+
+    try {
+      const res = await fetch(
+        `/api/profiles?search=${encodeURIComponent(q)}&limit=20`,
+        { signal: controller.signal }
+      );
+      if (!res.ok) throw new Error("fetch failed");
+      const json = await res.json();
+
+      const profiles: MockProfile[] = (json.data as ProfileApiRow[])
+        .map((row) =>
+          dbRowToProfile({
+            githubLogin: row.githubLogin,
+            avatarUrl: row.avatarUrl,
+            totalScore: row.totalScore,
+            tier: row.tier,
+            dimensionScores: row.dimensionScores ?? null,
+            manifestSnapshot: null,
+          })
+        )
+        .filter((p): p is MockProfile => p !== null);
+
+      setResults(profiles);
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        setResults([]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => fetchResults(query), 300);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query, fetchResults]);
+
+  const clear = () => {
+    setQuery("");
+    setResults([]);
+    setSearched(false);
+  };
+
+  const isActive = query.length >= 2;
+
+  return (
+    <>
+      {/* Search input */}
+      <div className="mb-6">
+        <div className="relative w-full sm:max-w-sm">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-white/40"
+            aria-hidden="true"
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by username..."
+            className="w-full rounded-lg border border-white/10 bg-[#12121a] py-2 pl-9 pr-9 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-indigo-500/50 transition-colors"
+            aria-label="Search profiles by username"
+          />
+          {query.length > 0 && (
+            <button
+              onClick={clear}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white transition-colors"
+              aria-label="Clear search"
+            >
+              <X size={16} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* When search is active, show search results; otherwise show default content */}
+      {isActive ? (
+        <div>
+          {loading && (
+            <p className="text-sm text-white/40 py-4">Searching...</p>
+          )}
+
+          {!loading && searched && results.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <h2 className="text-base font-semibold text-white/70">
+                No profile found for &lsquo;@{query}&rsquo;
+              </h2>
+              <p className="mt-2 text-sm text-white/40 max-w-xs">
+                Be the first to submit yours &mdash; run{" "}
+                <code className="font-mono text-emerald-400">
+                  npx agentscore export
+                </code>
+              </p>
+            </div>
+          )}
+
+          {!loading && results.length > 0 && (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {results.map((profile) => (
+                <ProfileCard key={profile.username} profile={profile} />
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        children
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a search input at the top of `/explore` for finding profiles by GitHub username
- API route (`GET /api/profiles`) now accepts `?search=` param with ILIKE prefix matching
- Debounced (300ms) client-side search replaces the server grid when active; clearing restores the default feed
- Empty state shown when no profiles match: "No profile found for '@{query}'"
- Clear (x) button on the input; full-width on mobile

## Test plan
- [ ] Navigate to `/explore` — search input visible above dimension filters
- [ ] Type 2+ characters — results appear (or empty state if no match)
- [ ] Clear input — default sorted feed restores
- [ ] Mobile (375px) — search input is full-width, no overflow
- [ ] `tsc --noEmit` passes (verified)
- [ ] All 112 tests pass (verified)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)