### PR TITLE
feat(navbar): auth-aware navbar with profile link and sign out

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,33 @@
 import Link from "next/link";
+import Image from "next/image";
+import { auth, signOut } from "@/auth";
 import { Button } from "@/components/ui/button";
 
-export default function Navbar() {
+async function getGithubLogin(githubId: string): Promise<string | null> {
+  try {
+    const { getDb } = await import("@/db");
+    const { profiles } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = getDb();
+    const rows = await db
+      .select({ githubLogin: profiles.githubLogin })
+      .from(profiles)
+      .where(eq(profiles.githubId, githubId))
+      .limit(1);
+    return rows[0]?.githubLogin ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function Navbar() {
+  const session = await auth();
+  const isSignedIn = !!session?.user?.id;
+  const githubLogin = isSignedIn
+    ? await getGithubLogin(session!.user!.id!)
+    : null;
+  const avatarUrl = session?.user?.image ?? null;
+
   return (
     <header className="sticky top-0 z-50 h-16 border-b border-white/10 bg-[#0a0a0f]/80 backdrop-blur-sm">
       <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4 md:px-8">
@@ -37,14 +63,53 @@ export default function Navbar() {
           >
             GitHub
           </Link>
-          <Button
-            variant="outline"
-            size="sm"
-            render={<Link href="/upload" />}
-            className="border-white/20 text-white hover:bg-white/10 hover:text-white"
-          >
-            Sign In
-          </Button>
+
+          {isSignedIn ? (
+            <div className="flex items-center gap-3">
+              <Link
+                href={githubLogin ? `/u/${githubLogin}` : "/upload"}
+                className="flex items-center gap-2 text-sm text-white/70 hover:text-white transition-colors"
+              >
+                {avatarUrl && (
+                  <Image
+                    src={avatarUrl}
+                    alt=""
+                    width={28}
+                    height={28}
+                    className="rounded-full"
+                    unoptimized
+                  />
+                )}
+                {githubLogin && (
+                  <span className="hidden sm:inline font-mono text-xs">
+                    @{githubLogin}
+                  </span>
+                )}
+              </Link>
+              <form
+                action={async () => {
+                  "use server";
+                  await signOut({ redirectTo: "/" });
+                }}
+              >
+                <button
+                  type="submit"
+                  className="text-xs text-white/40 hover:text-white/70 transition-colors"
+                >
+                  Sign out
+                </button>
+              </form>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              render={<Link href="/upload" />}
+              className="border-white/20 text-white hover:bg-white/10 hover:text-white"
+            >
+              Sign In
+            </Button>
+          )}
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Navbar is now an async server component that reads the session via `auth()`
- Signed-in: shows GitHub avatar (28px), `@username` linking to profile, and a "Sign out" button
- Signed-out: shows the existing "Sign In" button (no change)
- Username fetched from DB via `githubId` to link to the correct profile page
- Sign-out uses NextAuth's `signOut()` server action

## Test plan
- [ ] Signed-out: "Sign In" button visible, links to `/upload`
- [ ] Signed-in: avatar + @username visible, links to `/u/{username}`
- [ ] Sign out action redirects to `/`
- [ ] Navbar stays sticky with dark theme styling
- [ ] Mobile nav items (`hidden sm:inline`) remain unaffected
- [ ] `tsc --noEmit` passes (verified)
- [ ] All tests pass (verified)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)