### PR TITLE
feat(profile): sticky anchor navigation for sections

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -17,6 +17,7 @@ import FullReport from "@/components/FullReport";
 import LevelUp from "@/components/LevelUp";
 import DownloadInfographic from "@/components/DownloadInfographic";
 import ScoreHistory from "@/components/ScoreHistory";
+import ProfileNav from "@/components/ProfileNav";
 import { getMockProfile } from "@/lib/mock-profiles";
 import { dbRowToProfile } from "@/lib/db-to-profile";
 import type { MockDimensionScore } from "@/lib/mock-profiles";
@@ -266,8 +267,11 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
             </a>
           </div>
 
+          {/* Section anchor nav */}
+          <ProfileNav />
+
           {/* Hero chart + score card */}
-          <div className="flex flex-col items-center gap-6 mb-14">
+          <div id="overview" className="flex flex-col items-center gap-6 mb-14">
             <div className="rounded-2xl bg-[#12121a] border border-white/10 p-6 w-full max-w-lg">
               <RadarChart dimensions={profile.dimensions} size="hero" />
             </div>
@@ -335,7 +339,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           )}
 
           {/* Report section */}
-          <div className="mx-auto max-w-3xl space-y-8 mb-14">
+          <div id="report" className="mx-auto max-w-3xl space-y-8 mb-14">
             {/* Personality */}
             <div className="rounded-xl bg-[#12121a] border border-indigo-500/20 p-6">
               <h2 className="text-xs uppercase tracking-widest text-indigo-400 mb-3">
@@ -452,12 +456,12 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           </div>
 
           {/* Level Up — improvement roadmap */}
-          <div className="mx-auto max-w-3xl mb-14">
+          <div id="levelup" className="mx-auto max-w-3xl mb-14">
             <LevelUp profile={profile} />
           </div>
 
           {/* Dimension breakdown */}
-          <div className="mb-14">
+          <div id="breakdown" className="mb-14">
             <h2 className="text-lg font-semibold text-white mb-6">
               Score Breakdown
             </h2>
@@ -513,7 +517,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           </div>
 
           {/* Manifest Overview */}
-          <div className="rounded-xl bg-[#12121a] border border-white/10 p-6 mb-10">
+          <div id="manifest" className="rounded-xl bg-[#12121a] border border-white/10 p-6 mb-10">
             <h2 className="text-lg font-semibold text-white mb-6">
               Manifest Overview
             </h2>

--- a/src/components/ProfileNav.tsx
+++ b/src/components/ProfileNav.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+const SECTIONS = [
+  { id: "overview", label: "Overview" },
+  { id: "report", label: "Report" },
+  { id: "levelup", label: "Level Up" },
+  { id: "breakdown", label: "Breakdown" },
+  { id: "manifest", label: "Manifest" },
+] as const;
+
+export default function ProfileNav() {
+  const [active, setActive] = useState("overview");
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const elements = SECTIONS.map((s) => document.getElementById(s.id)).filter(
+      Boolean
+    ) as HTMLElement[];
+
+    if (elements.length === 0) return;
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        // Find the topmost visible section
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort(
+            (a, b) =>
+              a.boundingClientRect.top - b.boundingClientRect.top
+          );
+        if (visible.length > 0) {
+          setActive(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-80px 0px -60% 0px", threshold: 0 }
+    );
+
+    elements.forEach((el) => observerRef.current!.observe(el));
+
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const offset = 80 + 48; // navbar (64px) + anchor nav (~48px) + gap
+    const top = el.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top, behavior: "smooth" });
+  };
+
+  return (
+    <nav className="sticky top-16 z-40 -mx-4 border-b border-white/10 bg-[#0a0a0f]/90 backdrop-blur-sm">
+      <div className="mx-auto max-w-5xl overflow-x-auto scrollbar-none px-4">
+        <div className="flex gap-1 py-2 min-w-max">
+          {SECTIONS.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => scrollTo(s.id)}
+              className={`shrink-0 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                active === s.id
+                  ? "bg-indigo-500/15 text-indigo-400"
+                  : "text-white/40 hover:text-white/70"
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- New `ProfileNav` client component: sticky horizontal nav with 5 section links
- IntersectionObserver highlights the active section as user scrolls
- Smooth-scroll on click with offset for both navbars (64px + 48px)
- `id` attributes added to Overview, Report, Level Up, Breakdown, Manifest sections
- Horizontally scrollable on narrow viewports

## Test plan
- [ ] Nav visible below profile header on `/u/wkliwk`
- [ ] Click "Breakdown" — smooth scrolls to Score Breakdown section
- [ ] "Breakdown" highlighted in indigo after scroll (verified via screenshot)
- [ ] Nav sticks below main Navbar when scrolling
- [ ] Mobile: nav scrolls horizontally without wrapping
- [ ] `tsc --noEmit` passes (verified)
- [ ] All tests pass (verified)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)