### PR TITLE
feat(explore): add tier filter to Explore page

### DIFF
--- a/src/app/explore/__tests__/tier-filter.test.ts
+++ b/src/app/explore/__tests__/tier-filter.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import type { MockProfile } from "@/lib/mock-profiles";
+import type { TierLabel } from "@/lib/scoring/types";
+
+function makeProfile(username: string, tier: TierLabel): MockProfile {
+  return {
+    username,
+    avatarUrl: `https://github.com/${username}.png`,
+    composite: 5,
+    tier,
+    tierDescription: "Building Momentum",
+    personality: "",
+    dimensions: [],
+    agents: [],
+    mcpServers: [],
+    commands: [],
+    hooks: [],
+    strengths: [],
+    growthAreas: [],
+    nextSteps: [],
+  };
+}
+
+function filterByTier(profiles: MockProfile[], tier: string | undefined): MockProfile[] {
+  if (!tier || tier === "all") return profiles;
+  return profiles.filter((p) => p.tier === tier);
+}
+
+const PROFILES: MockProfile[] = [
+  makeProfile("a", "Beginner"),
+  makeProfile("b", "Intermediate"),
+  makeProfile("c", "Advanced"),
+  makeProfile("d", "Expert"),
+  makeProfile("e", "Master"),
+  makeProfile("f", "Master"),
+];
+
+describe("explore page — tier filter", () => {
+  it("returns all profiles when tier is 'all'", () => {
+    expect(filterByTier(PROFILES, "all")).toHaveLength(6);
+  });
+
+  it("returns all profiles when tier is undefined", () => {
+    expect(filterByTier(PROFILES, undefined)).toHaveLength(6);
+  });
+
+  it("filters to only Beginner profiles", () => {
+    const result = filterByTier(PROFILES, "Beginner");
+    expect(result).toHaveLength(1);
+    expect(result[0].username).toBe("a");
+  });
+
+  it("filters to only Master profiles", () => {
+    const result = filterByTier(PROFILES, "Master");
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.username)).toEqual(["e", "f"]);
+  });
+
+  it("returns empty array when no profiles match the tier", () => {
+    const result = filterByTier([makeProfile("x", "Beginner")], "Expert");
+    expect(result).toHaveLength(0);
+  });
+
+  it("composes correctly — tier filter applied after a pre-sorted list", () => {
+    const sorted = [...PROFILES].reverse();
+    const result = filterByTier(sorted, "Master");
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.username)).toEqual(["f", "e"]);
+  });
+});

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -8,14 +8,17 @@ import ExploreSearch from "@/components/ExploreSearch";
 import { MOCK_PROFILES } from "@/lib/mock-profiles";
 import { dbRowToProfile } from "@/lib/db-to-profile";
 import type { MockProfile } from "@/lib/mock-profiles";
-import type { DimensionKey } from "@/lib/scoring/types";
+import type { DimensionKey, TierLabel } from "@/lib/scoring/types";
 
 export const revalidate = 60;
+
+const VALID_TIERS: TierLabel[] = ["Beginner", "Intermediate", "Advanced", "Expert", "Master"];
 
 interface ExplorePageProps {
   searchParams: Promise<{
     sort?: string;
     dimension?: string;
+    tier?: string;
     page?: string;
   }>;
 }
@@ -33,9 +36,24 @@ function filterByDimension(
   });
 }
 
+function filterByTier(
+  profiles: MockProfile[],
+  tier: string | undefined
+): MockProfile[] {
+  if (!tier || tier === "all") return profiles;
+  return profiles.filter((p) => p.tier === tier);
+}
+
+function parseTier(raw: string | undefined): TierLabel | "all" {
+  if (!raw || raw === "all") return "all";
+  if ((VALID_TIERS as string[]).includes(raw)) return raw as TierLabel;
+  return "all";
+}
+
 async function fetchDbProfiles(
   sort: string,
-  page: number
+  page: number,
+  tier: TierLabel | "all"
 ): Promise<{ profiles: MockProfile[]; hasMore: boolean } | null> {
   try {
     const { getDb } = await import("@/db");
@@ -44,6 +62,9 @@ async function fetchDbProfiles(
 
     const limit = PAGE_SIZE;
     const offset = (page - 1) * limit;
+
+    const tierCondition =
+      tier !== "all" ? eq(profilesTable.tier, tier) : undefined;
 
     if (sort === "imports") {
       // Join profiles with bundles, order by importCount descending
@@ -73,7 +94,8 @@ async function fetchDbProfiles(
           and(
             eq(profilesTable.visibility, "public"),
             gte(profilesTable.totalScore, 0),
-            isNotNull(bundlesTable.importCount)
+            isNotNull(bundlesTable.importCount),
+            tierCondition
           )
         )
         .orderBy(desc(bundlesTable.importCount))
@@ -113,7 +135,13 @@ async function fetchDbProfiles(
     const rows = await db
       .select()
       .from(profilesTable)
-      .where(and(eq(profilesTable.visibility, "public"), gte(profilesTable.totalScore, 0)))
+      .where(
+        and(
+          eq(profilesTable.visibility, "public"),
+          gte(profilesTable.totalScore, 0),
+          tierCondition
+        )
+      )
       .orderBy(orderBy)
       .limit(limit + 1)
       .offset(offset);
@@ -156,6 +184,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
         ? "imports"
         : "newest";
   const dimension = params.dimension ?? "all";
+  const tier = parseTier(params.tier);
   const page = Math.max(1, parseInt(params.page ?? "1", 10));
 
   let profiles: MockProfile[] = [];
@@ -163,7 +192,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
   let hasMore = false;
 
   const [dbResult, profileCount] = await Promise.all([
-    fetchDbProfiles(sort, page),
+    fetchDbProfiles(sort, page, tier),
     fetchProfileCount(),
   ]);
 
@@ -181,11 +210,14 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
               (a, b) => (b.bundle?.importCount ?? 0) - (a.bundle?.importCount ?? 0)
             )
           : [...MOCK_PROFILES];
-    const filtered = filterByDimension(sorted, dimension);
+    const byDimension = filterByDimension(sorted, dimension);
+    const filtered = filterByTier(byDimension, tier);
     const start = (page - 1) * PAGE_SIZE;
     profiles = filtered.slice(start, start + PAGE_SIZE);
     hasMore = start + PAGE_SIZE < filtered.length;
   }
+
+  const paginationBase = `sort=${sort}&dimension=${dimension}&tier=${tier}`;
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -217,7 +249,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
           {/* Search + content (search hides default content when active) */}
           <ExploreSearch>
             {/* Filters */}
-            <ExploreFilters sort={sort} dimension={dimension} />
+            <ExploreFilters sort={sort} dimension={dimension} tier={tier} />
 
             {/* Grid */}
             {profiles.length === 0 ? (
@@ -257,7 +289,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
               <div className="mt-10 flex items-center justify-center gap-3">
                 {page > 1 && (
                   <Link
-                    href={`/explore?sort=${sort}&dimension=${dimension}&page=${page - 1}`}
+                    href={`/explore?${paginationBase}&page=${page - 1}`}
                     className="rounded-lg border border-white/15 bg-[#12121a] px-4 py-2 text-sm text-white/70 hover:text-white hover:border-white/30 transition-colors"
                   >
                     &larr; Prev
@@ -266,7 +298,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
                 <span className="text-sm text-white/40">Page {page}</span>
                 {hasMore && (
                   <Link
-                    href={`/explore?sort=${sort}&dimension=${dimension}&page=${page + 1}`}
+                    href={`/explore?${paginationBase}&page=${page + 1}`}
                     className="rounded-lg border border-white/15 bg-[#12121a] px-4 py-2 text-sm text-white/70 hover:text-white hover:border-white/30 transition-colors"
                   >
                     Next &rarr;

--- a/src/components/ExploreFilters.tsx
+++ b/src/components/ExploreFilters.tsx
@@ -2,10 +2,12 @@
 
 import { useRouter, usePathname } from "next/navigation";
 import { useCallback } from "react";
+import type { TierLabel } from "@/lib/scoring/types";
 
 interface ExploreFiltersProps {
   sort: string;
   dimension: string;
+  tier: string;
 }
 
 const DIMENSIONS = [
@@ -26,7 +28,53 @@ const SORT_OPTIONS = [
 
 type SortValue = (typeof SORT_OPTIONS)[number]["value"];
 
-export default function ExploreFilters({ sort, dimension }: ExploreFiltersProps) {
+interface TierOption {
+  value: TierLabel | "all";
+  label: string;
+  activeClass: string;
+  inactiveClass: string;
+}
+
+const TIER_OPTIONS: TierOption[] = [
+  {
+    value: "all",
+    label: "All tiers",
+    activeClass: "border-white/40 bg-white/10 text-white",
+    inactiveClass: "border-white/10 text-white/40 hover:text-white/70 hover:border-white/20",
+  },
+  {
+    value: "Beginner",
+    label: "Beginner",
+    activeClass: "border-slate-400/60 bg-slate-400/20 text-slate-300",
+    inactiveClass: "border-slate-400/20 text-slate-400/50 hover:text-slate-400/80 hover:border-slate-400/40",
+  },
+  {
+    value: "Intermediate",
+    label: "Intermediate",
+    activeClass: "border-emerald-400/60 bg-emerald-400/20 text-emerald-300",
+    inactiveClass: "border-emerald-400/20 text-emerald-400/50 hover:text-emerald-400/80 hover:border-emerald-400/40",
+  },
+  {
+    value: "Advanced",
+    label: "Advanced",
+    activeClass: "border-blue-400/60 bg-blue-400/20 text-blue-300",
+    inactiveClass: "border-blue-400/20 text-blue-400/50 hover:text-blue-400/80 hover:border-blue-400/40",
+  },
+  {
+    value: "Expert",
+    label: "Expert",
+    activeClass: "border-violet-400/60 bg-violet-400/20 text-violet-300",
+    inactiveClass: "border-violet-400/20 text-violet-400/50 hover:text-violet-400/80 hover:border-violet-400/40",
+  },
+  {
+    value: "Master",
+    label: "Master",
+    activeClass: "border-amber-400/60 bg-amber-400/20 text-amber-300",
+    inactiveClass: "border-amber-400/20 text-amber-400/50 hover:text-amber-400/80 hover:border-amber-400/40",
+  },
+];
+
+export default function ExploreFilters({ sort, dimension, tier }: ExploreFiltersProps) {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -35,49 +83,71 @@ export default function ExploreFilters({ sort, dimension }: ExploreFiltersProps)
       const params = new URLSearchParams();
       if (key !== "sort") params.set("sort", sort);
       if (key !== "dimension") params.set("dimension", dimension);
+      if (key !== "tier") params.set("tier", tier);
       params.set(key, value);
       params.set("page", "1");
       router.push(`${pathname}?${params.toString()}`);
     },
-    [router, pathname, sort, dimension]
+    [router, pathname, sort, dimension, tier]
   );
 
   return (
-    <div className="mb-6 flex flex-wrap items-center gap-3">
-      {/* Sort toggle */}
-      <div className="flex rounded-lg border border-white/10 overflow-hidden">
-        {SORT_OPTIONS.map((s: { value: SortValue; label: string }) => (
-          <button
-            key={s.value}
-            onClick={() => updateParams("sort", s.value)}
-            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-              sort === s.value
-                ? "bg-indigo-500 text-white"
-                : "bg-[#12121a] text-white/50 hover:text-white"
-            }`}
+    <div className="mb-6 flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Sort toggle */}
+        <div className="flex rounded-lg border border-white/10 overflow-hidden">
+          {SORT_OPTIONS.map((s: { value: SortValue; label: string }) => (
+            <button
+              key={s.value}
+              onClick={() => updateParams("sort", s.value)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                sort === s.value
+                  ? "bg-indigo-500 text-white"
+                  : "bg-[#12121a] text-white/50 hover:text-white"
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Dimension select */}
+        <div className="relative">
+          <select
+            value={dimension}
+            onChange={(e) => updateParams("dimension", e.target.value)}
+            className="appearance-none rounded-lg border border-white/10 bg-[#12121a] px-3 py-1.5 pr-7 text-xs text-white/70 hover:text-white focus:outline-none focus:border-indigo-500/50 transition-colors cursor-pointer"
+            aria-label="Filter by dimension"
           >
-            {s.label}
-          </button>
-        ))}
+            {DIMENSIONS.map((d) => (
+              <option key={d.value} value={d.value} className="bg-[#12121a] text-white">
+                {d.label}
+              </option>
+            ))}
+          </select>
+          <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-white/40 text-xs">
+            ▾
+          </span>
+        </div>
       </div>
 
-      {/* Dimension select */}
-      <div className="relative">
-        <select
-          value={dimension}
-          onChange={(e) => updateParams("dimension", e.target.value)}
-          className="appearance-none rounded-lg border border-white/10 bg-[#12121a] px-3 py-1.5 pr-7 text-xs text-white/70 hover:text-white focus:outline-none focus:border-indigo-500/50 transition-colors cursor-pointer"
-          aria-label="Filter by dimension"
-        >
-          {DIMENSIONS.map((d) => (
-            <option key={d.value} value={d.value} className="bg-[#12121a] text-white">
-              {d.label}
-            </option>
-          ))}
-        </select>
-        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-white/40 text-xs">
-          ▾
-        </span>
+      {/* Tier pills */}
+      <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Filter by tier">
+        {TIER_OPTIONS.map((t) => {
+          const isActive = tier === t.value;
+          return (
+            <button
+              key={t.value}
+              onClick={() => updateParams("tier", t.value)}
+              aria-pressed={isActive}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors bg-[#12121a] ${
+                isActive ? t.activeClass : t.inactiveClass
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Adds a tier filter to the Explore page with five pill buttons (Beginner / Intermediate / Advanced / Expert / Master) displayed below the existing sort and dimension controls. Each tier pill uses a colour accent matching the tier's visual identity (slate / emerald / blue / violet / amber).

## Why

Closes #53

## Acceptance Criteria

- [x] Tier filter is displayed alongside the existing sort and dimension controls on Explore
- [x] Selecting a tier filters the DB query to only return profiles at that tier (via `eq(profilesTable.tier, tier)` condition)
- [x] "All tiers" (no filter) is the default selection
- [x] Tier filter persists in the URL as a query param (e.g. `?tier=Master`) so the URL is shareable
- [x] Tier filter composes correctly with sort and dimension filters (all three can be active simultaneously)
- [x] Mock data fallback also respects the tier filter (`filterByTier` applied after `filterByDimension`)
- [x] Filter UI matches existing design: pill/button style with tier colour accents

## Changes

- `src/components/ExploreFilters.tsx` — added `tier` prop, `TIER_OPTIONS` array with colour classes, tier pill buttons with `aria-pressed`, and `tier` param preservation in `updateParams`
- `src/app/explore/page.tsx` — added `tier?` to `ExplorePageProps.searchParams`, `parseTier()` guard, `filterByTier()` for mock data, tier condition in both DB query paths, and `tier` included in pagination links
- `src/app/explore/__tests__/tier-filter.test.ts` — 6 unit tests covering all/undefined passthrough, single-tier match, multi-match, zero-match, and composition with pre-sorted list

## Test Plan

1. Navigate to `/explore` — "All tiers" pill is active, all profiles visible
2. Click "Master" — URL updates to `?tier=Master`, only Master profiles shown
3. Click "Beginner" — URL updates to `?tier=Beginner`, only Beginner profiles shown
4. While on a tier filter, change sort to "Highest Score" — tier param preserved in URL
5. While on a tier filter, change dimension — tier param preserved in URL
6. Navigate directly to `/explore?tier=Master&sort=score&dimension=automation` — all three filters active simultaneously
7. Navigate to `/explore?tier=InvalidValue` — falls back to "All tiers" silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)