### PR TITLE
feat(profile): score history line chart

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -17,6 +17,7 @@ import FullReport from "@/components/FullReport";
 import LevelUp from "@/components/LevelUp";
 import DownloadInfographic from "@/components/DownloadInfographic";
 import ScoreHistory from "@/components/ScoreHistory";
+import ScoreHistoryChart from "@/components/ScoreHistoryChart";
 import ProfileNav from "@/components/ProfileNav";
 import { getMockProfile } from "@/lib/mock-profiles";
 import { dbRowToProfile } from "@/lib/db-to-profile";
@@ -130,13 +131,25 @@ function DimensionCard({ dim }: { dim: MockDimensionScore }) {
   );
 }
 
+export interface ScoreHistoryEntry {
+  totalScore: number;
+  scoredAt: string;
+}
+
+interface ScoreHistoryResult {
+  count: number;
+  previousScore: number | null;
+  scoredAt: string | null;
+  entries: ScoreHistoryEntry[];
+}
+
 async function fetchScoreHistory(
   username: string
-): Promise<{ count: number; previousScore: number | null; scoredAt: string | null }> {
+): Promise<ScoreHistoryResult> {
   try {
     const { getDb } = await import("@/db");
     const { profiles, scoreHistory } = await import("@/db/schema");
-    const { eq, desc } = await import("drizzle-orm");
+    const { eq, desc, asc } = await import("drizzle-orm");
     const db = getDb();
 
     // Get profile ID
@@ -146,26 +159,39 @@ async function fetchScoreHistory(
       .where(eq(profiles.githubLogin, username))
       .limit(1);
     if (profileRows.length === 0)
-      return { count: 0, previousScore: null, scoredAt: null };
+      return { count: 0, previousScore: null, scoredAt: null, entries: [] };
 
     const profileId = profileRows[0].id;
     const scoredAt = profileRows[0].scoredAt?.toISOString() ?? null;
 
-    // Get the two most recent score history entries
+    // Get all history entries (oldest first for chart)
     const historyRows = await db
-      .select({ totalScore: scoreHistory.totalScore })
+      .select({
+        totalScore: scoreHistory.totalScore,
+        scoredAt: scoreHistory.scoredAt,
+      })
       .from(scoreHistory)
       .where(eq(scoreHistory.profileId, profileId))
-      .orderBy(desc(scoreHistory.scoredAt))
-      .limit(2);
+      .orderBy(asc(scoreHistory.scoredAt))
+      .limit(50);
+
+    const entries: ScoreHistoryEntry[] = historyRows.map((r) => ({
+      totalScore: r.totalScore,
+      scoredAt: r.scoredAt.toISOString(),
+    }));
+
+    // Previous score = second most recent (entries are asc, so second-to-last)
+    const previousScore =
+      entries.length >= 2 ? entries[entries.length - 2].totalScore : null;
 
     return {
-      count: historyRows.length,
-      previousScore: historyRows.length >= 2 ? historyRows[1].totalScore : null,
+      count: entries.length,
+      previousScore,
       scoredAt,
+      entries,
     };
   } catch {
-    return { count: 0, previousScore: null, scoredAt: null };
+    return { count: 0, previousScore: null, scoredAt: null, entries: [] };
   }
 }
 
@@ -315,6 +341,9 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                 <DownloadInfographic username={profile.username} />
               </div>
             </div>
+
+            {/* Score history chart */}
+            <ScoreHistoryChart entries={history.entries} />
           </div>
 
           {/* Bundle stats */}

--- a/src/components/ScoreHistoryChart.tsx
+++ b/src/components/ScoreHistoryChart.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+
+interface Entry {
+  totalScore: number;
+  scoredAt: string;
+}
+
+interface ScoreHistoryChartProps {
+  entries: Entry[];
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export default function ScoreHistoryChart({ entries }: ScoreHistoryChartProps) {
+  if (entries.length < 2) return null;
+
+  const data = entries.map((e) => ({
+    date: formatDate(e.scoredAt),
+    score: e.totalScore,
+  }));
+
+  return (
+    <div className="w-full max-w-sm rounded-xl bg-[#12121a] border border-white/10 p-4">
+      <p className="text-xs uppercase tracking-widest text-white/40 mb-3">
+        Score History
+      </p>
+      <ResponsiveContainer width="100%" height={140}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 10, fill: "rgba(255,255,255,0.3)" }}
+            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 10]}
+            tick={{ fontSize: 10, fill: "rgba(255,255,255,0.3)" }}
+            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+            tickLine={false}
+            width={24}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "#1a1a2e",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: "8px",
+              fontSize: "12px",
+              color: "rgba(255,255,255,0.8)",
+            }}
+            formatter={(value) => [`${value}`, "Score"]}
+          />
+          <Line
+            type="monotone"
+            dataKey="score"
+            stroke="#818cf8"
+            strokeWidth={2}
+            dot={{ fill: "#818cf8", r: 3 }}
+            activeDot={{ r: 5, fill: "#6366f1" }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extended `fetchScoreHistory` to return all entries (up to 50, oldest first)
- New `ScoreHistoryChart` component using recharts `LineChart`
- Chart renders only when 2+ history entries exist
- Dark theme: `#12121a` background, `indigo-400` line, dark tooltip
- Responsive via `ResponsiveContainer`
- Placed between score card and bundle stats in the overview section

## Test plan
- [ ] Profile with 2+ score history entries shows the chart
- [ ] Profile with 0-1 entries shows no chart (just existing "run CLI" message)
- [ ] Chart axes: X = date, Y = 0-10 score range
- [ ] Tooltip shows score on hover
- [ ] Chart doesn't overflow on mobile
- [ ] `tsc --noEmit` passes (verified)
- [ ] All 180 tests pass (verified)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)