### PR TITLE
fix(mobile): profile page layout on 375px viewports

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -260,7 +260,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   const isMaster = profile.tier === "Master";
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col overflow-x-hidden">
       <Navbar />
 
       <main className="flex-1 px-4 py-10 md:py-14">
@@ -336,7 +336,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                 isOwner={isOwner}
                 username={profile.username}
               />
-              <div className="mt-4 flex items-center justify-center gap-3">
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
                 <ShareButton username={profile.username} />
                 <DownloadInfographic username={profile.username} />
               </div>
@@ -348,18 +348,18 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
           {/* Bundle stats */}
           {profile.bundle && (
-            <div className="flex items-center justify-center gap-6 mb-10">
+            <div className="flex flex-wrap items-center justify-center gap-4 mb-10">
               <div className="flex items-center gap-2 text-sm text-white/50">
                 <GitFork size={14} className="text-indigo-400" />
                 <span className="font-mono text-white/70">{profile.bundle.importCount}</span>
                 <span>imports</span>
               </div>
-              <div className="h-3 w-px bg-white/10" />
+              <div className="hidden sm:block h-3 w-px bg-white/10" />
               <div className="flex items-center gap-2 text-sm text-white/50">
                 <span className="font-mono text-white/70">{profile.bundle.inspiredByCount}</span>
                 <span>users inspired</span>
               </div>
-              <div className="h-3 w-px bg-white/10" />
+              <div className="hidden sm:block h-3 w-px bg-white/10" />
               <div className="flex items-center gap-2 text-sm text-white/50">
                 <span className="font-mono text-white/70">{profile.bundle.fileCount}</span>
                 <span>files shared</span>

--- a/src/components/RadarChart.tsx
+++ b/src/components/RadarChart.tsx
@@ -5,6 +5,7 @@ import {
   RadarChart as RechartsRadarChart,
   PolarGrid,
   PolarAngleAxis,
+  ResponsiveContainer,
 } from "recharts";
 
 const DIMENSION_LABELS: Record<string, string> = {
@@ -29,7 +30,6 @@ export interface RadarChartProps {
 
 export default function RadarChart({ dimensions, size = "hero" }: RadarChartProps) {
   const isHero = size === "hero";
-  const containerSize = isHero ? 480 : 160;
   const fontSize = isHero ? 13 : 0; // thumbnail: hide labels to keep it clean
 
   const data = dimensions.map((d) => ({
@@ -38,36 +38,59 @@ export default function RadarChart({ dimensions, size = "hero" }: RadarChartProp
     fullMark: 10,
   }));
 
+  if (!isHero) {
+    // Thumbnail: fixed small size is intentional (used in OG/badge contexts, not profile page)
+    return (
+      <div style={{ width: 160, height: 160 }} className="mx-auto">
+        <RechartsRadarChart
+          width={160}
+          height={160}
+          cx="50%"
+          cy="50%"
+          outerRadius="70%"
+          data={data}
+        >
+          <PolarGrid stroke="rgba(255,255,255,0.1)" />
+          <Radar
+            name="Score"
+            dataKey="score"
+            stroke="#6366f1"
+            fill="#6366f1"
+            fillOpacity={0.25}
+            strokeWidth={1.5}
+            dot={false}
+          />
+        </RechartsRadarChart>
+      </div>
+    );
+  }
+
+  // Hero: use ResponsiveContainer so it never overflows on mobile viewports
   return (
-    <div
-      style={{ width: containerSize, height: containerSize }}
-      className="mx-auto"
-    >
-      <RechartsRadarChart
-        width={containerSize}
-        height={containerSize}
-        cx="50%"
-        cy="50%"
-        outerRadius={isHero ? "65%" : "70%"}
-        data={data}
-      >
-        <PolarGrid stroke="rgba(255,255,255,0.1)" />
-        {fontSize > 0 && (
+    <div className="w-full" style={{ height: 320 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsRadarChart
+          cx="50%"
+          cy="50%"
+          outerRadius="65%"
+          data={data}
+        >
+          <PolarGrid stroke="rgba(255,255,255,0.1)" />
           <PolarAngleAxis
             dataKey="subject"
             tick={{ fill: "rgba(255,255,255,0.8)", fontSize, fontFamily: "Inter, sans-serif" }}
           />
-        )}
-        <Radar
-          name="Score"
-          dataKey="score"
-          stroke="#6366f1"
-          fill="#6366f1"
-          fillOpacity={0.25}
-          strokeWidth={isHero ? 2 : 1.5}
-          dot={isHero ? { fill: "#6366f1", r: 3 } : false}
-        />
-      </RechartsRadarChart>
+          <Radar
+            name="Score"
+            dataKey="score"
+            stroke="#6366f1"
+            fill="#6366f1"
+            fillOpacity={0.25}
+            strokeWidth={2}
+            dot={{ fill: "#6366f1", r: 3 }}
+          />
+        </RechartsRadarChart>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/src/components/ScoreHistoryChart.tsx
+++ b/src/components/ScoreHistoryChart.tsx
@@ -33,7 +33,7 @@ export default function ScoreHistoryChart({ entries }: ScoreHistoryChartProps) {
   }));
 
   return (
-    <div className="w-full max-w-sm rounded-xl bg-[#12121a] border border-white/10 p-4">
+    <div className="w-full rounded-xl bg-[#12121a] border border-white/10 p-4">
       <p className="text-xs uppercase tracking-widest text-white/40 mb-3">
         Score History
       </p>


### PR DESCRIPTION
## What
Fix horizontal overflow and layout breakage on the `/u/{username}` profile page at 375px (iPhone SE) viewport width.

## Why
Closes #64

## Acceptance Criteria
- [x] No horizontal scroll at 375px
- [x] Radar chart responsive (ResponsiveContainer)
- [x] Score history chart responsive (removed max-w-sm)
- [x] Share buttons wrap on mobile
- [x] Bundle stats wrap on mobile
- [x] tsc --noEmit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)