### PR TITLE
fix(#41): pre-push build check + extract Navbar server action

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Run once after cloning: sh scripts/install-hooks.sh
+set -e
+HOOK=.git/hooks/pre-push
+cp scripts/pre-push.sh "$HOOK"
+chmod +x "$HOOK"
+echo "pre-push hook installed."

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Runs before every git push. Blocks push if next build fails.
+echo "Running build check before push..."
+npm run build:check
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+  echo ""
+  echo "Build check failed. Fix the errors above before pushing."
+  exit 1
+fi
+echo "Build check passed."

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { signOut } from "@/auth";
+
+export async function signOutAction() {
+  await signOut({ redirectTo: "/" });
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { auth, signOut } from "@/auth";
+import { auth } from "@/auth";
 import { Button } from "@/components/ui/button";
+import { signOutAction } from "@/app/actions";
 
 async function getGithubLogin(githubId: string): Promise<string | null> {
   try {
@@ -86,12 +87,7 @@ export default async function Navbar() {
                   </span>
                 )}
               </Link>
-              <form
-                action={async () => {
-                  "use server";
-                  await signOut({ redirectTo: "/" });
-                }}
-              >
+              <form action={signOutAction}>
                 <button
                   type="submit"
                   className="text-xs text-white/40 hover:text-white/70 transition-colors"


### PR DESCRIPTION
## Summary
- Adds `scripts/pre-push.sh` — runs `npm run build:check` before every `git push`, blocking if build fails
- Adds `scripts/install-hooks.sh` — one-time setup script for new devs: `sh scripts/install-hooks.sh`
- Extracts Navbar's inline `"use server"` action into `src/app/actions.ts` — fixes Turbopack error where inline server actions in components used in Client Component SSR contexts are not allowed

## Test plan
- [ ] `npm run build:check` passes clean
- [ ] Pre-push hook blocks bad pushes (verified: hook ran during `git push` of this PR)
- [ ] Navbar sign-out still works (same server action, just in a dedicated file)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)