### PR TITLE
feat: add side-by-side profile comparison page at /compare (#62)

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { signOut } from "@/auth";
+
+export async function signOutAction() {
+  await signOut({ redirectTo: "/" });
+}

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,415 @@
+import Link from "next/link";
+import Image from "next/image";
+import type { Metadata } from "next";
+import Navbar from "@/components/Navbar";
+import RadarChart from "@/components/RadarChart";
+import { getMockProfile } from "@/lib/mock-profiles";
+import { dbRowToProfile } from "@/lib/db-to-profile";
+import type { MockProfile } from "@/lib/mock-profiles";
+
+interface ComparePageProps {
+  searchParams: Promise<{
+    a?: string;
+    b?: string;
+  }>;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://agentscore.dev";
+
+export async function generateMetadata({
+  searchParams,
+}: ComparePageProps): Promise<Metadata> {
+  const { a, b } = await searchParams;
+  if (!a || !b) {
+    return { title: "Compare Profiles — AgentScore" };
+  }
+  return {
+    title: `Compare @${a} vs @${b} — AgentScore`,
+    description: `Side-by-side AgentScore comparison between @${a} and @${b}.`,
+    openGraph: {
+      title: `Compare @${a} vs @${b} — AgentScore`,
+      description: `Side-by-side AgentScore comparison between @${a} and @${b}.`,
+      url: `${BASE_URL}/compare?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`,
+    },
+  };
+}
+
+async function fetchProfile(username: string): Promise<MockProfile | null> {
+  // Try real DB first; fall back to mock
+  try {
+    const { getDb } = await import("@/db");
+    const { profiles } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.githubLogin, username))
+      .limit(1);
+    if (rows.length > 0) {
+      const profile = dbRowToProfile(rows[0]);
+      if (profile) return profile;
+    }
+  } catch {
+    // DB unavailable — fall through to mock
+  }
+  return getMockProfile(username);
+}
+
+const TIER_COLORS: Record<string, string> = {
+  Master: "#f59e0b",
+  Expert: "#f59e0b",
+  Advanced: "#8b5cf6",
+  Intermediate: "#3b82f6",
+  Beginner: "#6b7280",
+};
+
+const DIMENSION_ORDER = [
+  "automation",
+  "memory",
+  "agentCoverage",
+  "toolIntegrations",
+  "skillBreadth",
+  "workflowDepth",
+];
+
+function TierBadge({ tier }: { tier: string }) {
+  const color = TIER_COLORS[tier] ?? "#6b7280";
+  return (
+    <span
+      className="inline-block rounded-full px-2.5 py-0.5 text-xs font-medium"
+      style={{ backgroundColor: `${color}18`, color }}
+    >
+      {tier}
+    </span>
+  );
+}
+
+function ProfileColumn({
+  profile,
+  color,
+  isWinner,
+}: {
+  profile: MockProfile;
+  color: string;
+  isWinner: boolean;
+}) {
+  const tierColor = TIER_COLORS[profile.tier] ?? "#6b7280";
+  return (
+    <div className="flex flex-col items-center text-center">
+      {/* Winner indicator */}
+      <div className="h-6 mb-2 flex items-center">
+        {isWinner && (
+          <span
+            className="text-xs font-semibold uppercase tracking-widest px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: `${color}20`, color }}
+          >
+            Winner
+          </span>
+        )}
+      </div>
+
+      {/* Avatar */}
+      <div
+        className="h-16 w-16 rounded-full overflow-hidden mb-3"
+        style={{ boxShadow: `0 0 0 2px ${color}` }}
+      >
+        <Image
+          src={profile.avatarUrl}
+          alt={profile.username}
+          width={64}
+          height={64}
+          className="h-full w-full object-cover"
+          unoptimized
+        />
+      </div>
+
+      {/* Username linking to profile */}
+      <Link
+        href={`/u/${profile.username}`}
+        className="font-mono text-lg font-bold hover:underline transition-colors"
+        style={{ color }}
+      >
+        @{profile.username}
+      </Link>
+
+      {/* Composite score */}
+      <div
+        className="text-4xl font-bold mt-2 leading-none"
+        style={{ color: tierColor }}
+      >
+        {profile.composite}
+      </div>
+
+      {/* Tier badge */}
+      <div className="mt-2">
+        <TierBadge tier={profile.tier} />
+      </div>
+    </div>
+  );
+}
+
+export default async function ComparePage({ searchParams }: ComparePageProps) {
+  const { a, b } = await searchParams;
+
+  // Validate params present
+  if (!a || !b) {
+    return (
+      <div className="flex min-h-screen flex-col overflow-x-hidden">
+        <Navbar />
+        <main className="flex-1 flex items-center justify-center px-4 py-20">
+          <div className="rounded-xl bg-[#12121a] border border-white/10 p-10 text-center max-w-md">
+            <h1 className="text-xl font-bold text-white mb-3">Compare Profiles</h1>
+            <p className="text-white/50 text-sm">
+              Provide two usernames via{" "}
+              <span className="font-mono text-indigo-400">?a=username&b=username</span>{" "}
+              to compare their AgentScores side by side.
+            </p>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // Fetch both profiles in parallel
+  const [profileA, profileB] = await Promise.all([
+    fetchProfile(a),
+    fetchProfile(b),
+  ]);
+
+  // Handle not found
+  const notFoundUsernames: string[] = [];
+  if (!profileA) notFoundUsernames.push(a);
+  if (!profileB) notFoundUsernames.push(b);
+
+  if (notFoundUsernames.length > 0) {
+    return (
+      <div className="flex min-h-screen flex-col overflow-x-hidden">
+        <Navbar />
+        <main className="flex-1 flex items-center justify-center px-4 py-20">
+          <div className="rounded-xl bg-[#12121a] border border-red-500/20 p-10 text-center max-w-md">
+            <h1 className="text-xl font-bold text-white mb-3">Profile Not Found</h1>
+            {notFoundUsernames.map((u) => (
+              <p key={u} className="text-red-400 text-sm font-mono mb-1">
+                Profile not found: {u}
+              </p>
+            ))}
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // TypeScript: both are non-null after the check above
+  const pA = profileA as MockProfile;
+  const pB = profileB as MockProfile;
+
+  const isATied = pA.composite === pB.composite;
+  const isAWinner = pA.composite > pB.composite;
+  const isBWinner = pB.composite > pA.composite;
+
+  // Build dimension delta table in a consistent order
+  const dimensionRows = DIMENSION_ORDER.map((key) => {
+    const dimA = pA.dimensions.find((d) => d.dimension === key);
+    const dimB = pB.dimensions.find((d) => d.dimension === key);
+    const scoreA = dimA?.score ?? 0;
+    const scoreB = dimB?.score ?? 0;
+    const delta = scoreA - scoreB;
+    const label = dimA?.label ?? dimB?.label ?? key;
+    return { key, label, scoreA, scoreB, delta };
+  });
+
+  // Color scheme: indigo for A, amber for B
+  const colorA = "#6366f1";
+  const colorB = "#f59e0b";
+
+  return (
+    <div className="flex min-h-screen flex-col overflow-x-hidden">
+      <Navbar />
+
+      <main className="flex-1 px-4 py-10 md:py-14">
+        <div className="mx-auto max-w-4xl">
+
+          {/* Page title */}
+          <div className="text-center mb-10">
+            <p className="text-xs uppercase tracking-widest text-white/40 mb-2">
+              Profile Comparison
+            </p>
+            <h1 className="text-2xl font-bold text-white">
+              @{a} vs @{b}
+            </h1>
+          </div>
+
+          {/* Header: two profile columns side by side */}
+          <div className="rounded-2xl bg-[#12121a] border border-white/10 p-6 md:p-8 mb-8">
+            <div className="grid grid-cols-3 items-start gap-4">
+              {/* User A */}
+              <ProfileColumn
+                profile={pA}
+                color={colorA}
+                isWinner={isAWinner}
+              />
+
+              {/* VS divider */}
+              <div className="flex flex-col items-center justify-center py-8">
+                <div className="w-px flex-1 bg-white/10" />
+                <span className="my-3 text-xs font-mono text-white/30 uppercase tracking-widest">
+                  vs
+                </span>
+                <div className="w-px flex-1 bg-white/10" />
+                {isATied && (
+                  <span className="mt-2 text-xs text-white/40">Tied</span>
+                )}
+              </div>
+
+              {/* User B */}
+              <ProfileColumn
+                profile={pB}
+                color={colorB}
+                isWinner={isBWinner}
+              />
+            </div>
+          </div>
+
+          {/* Overlaid radar chart */}
+          <div className="rounded-2xl bg-[#12121a] border border-white/10 p-6 mb-8">
+            <h2 className="text-sm uppercase tracking-widest text-white/40 mb-4">
+              Dimension Radar
+            </h2>
+            <RadarChart
+              dimensions={pA.dimensions}
+              secondDimensions={pB.dimensions}
+              labelA={`@${a}`}
+              labelB={`@${b}`}
+              size="hero"
+            />
+          </div>
+
+          {/* Delta table */}
+          <div className="rounded-2xl bg-[#12121a] border border-white/10 overflow-hidden mb-8">
+            <div className="px-6 py-4 border-b border-white/10">
+              <h2 className="text-sm uppercase tracking-widest text-white/40">
+                Dimension Breakdown
+              </h2>
+            </div>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white/40 uppercase tracking-wider">
+                    Dimension
+                  </th>
+                  <th
+                    className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider"
+                    style={{ color: colorA }}
+                  >
+                    @{a}
+                  </th>
+                  <th
+                    className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider"
+                    style={{ color: colorB }}
+                  >
+                    @{b}
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium text-white/40 uppercase tracking-wider">
+                    Delta
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {dimensionRows.map(({ key, label, scoreA, scoreB, delta }) => {
+                  const aWins = delta > 0;
+                  const bWins = delta < 0;
+                  return (
+                    <tr
+                      key={key}
+                      className="border-b border-white/5 last:border-0 transition-colors hover:bg-white/5"
+                    >
+                      <td className="px-6 py-3 text-white/70 font-medium">
+                        {label}
+                      </td>
+                      <td className="px-4 py-3 text-center">
+                        <span
+                          className={`font-mono font-bold ${aWins ? "text-white" : "text-white/40"}`}
+                        >
+                          {scoreA}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-center">
+                        <span
+                          className={`font-mono font-bold ${bWins ? "text-white" : "text-white/40"}`}
+                        >
+                          {scoreB}
+                        </span>
+                      </td>
+                      <td className="px-6 py-3 text-right">
+                        {delta === 0 ? (
+                          <span className="text-white/30 font-mono text-xs">Tied</span>
+                        ) : (
+                          <span
+                            className="font-mono text-xs font-semibold px-2 py-0.5 rounded"
+                            style={
+                              aWins
+                                ? {
+                                    backgroundColor: `${colorA}18`,
+                                    color: colorA,
+                                  }
+                                : {
+                                    backgroundColor: `${colorB}18`,
+                                    color: colorB,
+                                  }
+                            }
+                          >
+                            {aWins ? "+" : ""}{delta.toFixed(1)} {aWins ? `@${a}` : `@${b}`} wins
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Links back to full profiles */}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Link
+              href={`/u/${a}`}
+              className="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium border transition-colors"
+              style={{
+                borderColor: `${colorA}50`,
+                color: colorA,
+              }}
+            >
+              View @{a}&apos;s full profile
+            </Link>
+            <Link
+              href={`/u/${b}`}
+              className="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium border transition-colors"
+              style={{
+                borderColor: `${colorB}50`,
+                color: colorB,
+              }}
+            >
+              View @{b}&apos;s full profile
+            </Link>
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-white/10 px-4 py-6 mt-10">
+        <div className="mx-auto max-w-7xl text-center text-xs text-white/30">
+          AgentScore —{" "}
+          <a
+            href="https://github.com/wkliwk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white/60 transition-colors"
+          >
+            @wkliwk
+          </a>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -13,6 +13,7 @@ import {
 import Navbar from "@/components/Navbar";
 import RadarChart from "@/components/RadarChart";
 import ShareButton from "@/components/ShareButton";
+import CompareButton from "@/components/CompareButton";
 import FullReport from "@/components/FullReport";
 import LevelUp from "@/components/LevelUp";
 import DownloadInfographic from "@/components/DownloadInfographic";
@@ -339,6 +340,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
               <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
                 <ShareButton username={profile.username} score={profile.composite} tier={profile.tier} />
                 <DownloadInfographic username={profile.username} />
+                <CompareButton username={profile.username} />
               </div>
             </div>
 

--- a/src/components/CompareButton.tsx
+++ b/src/components/CompareButton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { GitCompareArrows } from "lucide-react";
+
+interface CompareButtonProps {
+  username: string;
+}
+
+export default function CompareButton({ username }: CompareButtonProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [otherUsername, setOtherUsername] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  const handleExpand = () => {
+    setExpanded(true);
+    // Focus input after state update
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const handleCompare = () => {
+    const trimmed = otherUsername.trim().replace(/^@/, "");
+    if (!trimmed) return;
+    router.push(`/compare?a=${encodeURIComponent(username)}&b=${encodeURIComponent(trimmed)}`);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") handleCompare();
+    if (e.key === "Escape") {
+      setExpanded(false);
+      setOtherUsername("");
+    }
+  };
+
+  if (!expanded) {
+    return (
+      <button
+        onClick={handleExpand}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-white/20 px-3 py-1.5 text-xs font-medium text-white/70 hover:text-white hover:border-white/40 transition-colors"
+        aria-label="Compare with another user"
+      >
+        <GitCompareArrows size={13} />
+        Compare
+      </button>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-lg border border-indigo-500/40 bg-indigo-500/5 px-2 py-1">
+      <GitCompareArrows size={13} className="text-indigo-400 shrink-0" />
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="@username"
+        value={otherUsername}
+        onChange={(e) => setOtherUsername(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="w-28 bg-transparent text-xs text-white placeholder-white/30 outline-none font-mono"
+        aria-label="Enter username to compare with"
+      />
+      <button
+        onClick={handleCompare}
+        disabled={!otherUsername.trim()}
+        className="text-xs font-medium text-indigo-400 hover:text-indigo-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+      >
+        Go
+      </button>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { auth, signOut } from "@/auth";
+import { auth } from "@/auth";
 import { Button } from "@/components/ui/button";
+import { signOutAction } from "@/app/actions";
 
 async function getGithubLogin(githubId: string): Promise<string | null> {
   try {
@@ -86,12 +87,7 @@ export default async function Navbar() {
                   </span>
                 )}
               </Link>
-              <form
-                action={async () => {
-                  "use server";
-                  await signOut({ redirectTo: "/" });
-                }}
-              >
+              <form action={signOutAction}>
                 <button
                   type="submit"
                   className="text-xs text-white/40 hover:text-white/70 transition-colors"

--- a/src/components/RadarChart.tsx
+++ b/src/components/RadarChart.tsx
@@ -6,6 +6,7 @@ import {
   PolarGrid,
   PolarAngleAxis,
   ResponsiveContainer,
+  Legend,
 } from "recharts";
 
 const DIMENSION_LABELS: Record<string, string> = {
@@ -26,17 +27,39 @@ export interface RadarDimension {
 export interface RadarChartProps {
   dimensions: RadarDimension[];
   size?: "hero" | "thumbnail";
+  /** Optional second data series for comparison mode */
+  secondDimensions?: RadarDimension[];
+  /** Legend label for the first series (used when secondDimensions provided) */
+  labelA?: string;
+  /** Legend label for the second series (used when secondDimensions provided) */
+  labelB?: string;
 }
 
-export default function RadarChart({ dimensions, size = "hero" }: RadarChartProps) {
+export default function RadarChart({
+  dimensions,
+  size = "hero",
+  secondDimensions,
+  labelA = "User A",
+  labelB = "User B",
+}: RadarChartProps) {
   const isHero = size === "hero";
   const fontSize = isHero ? 13 : 0; // thumbnail: hide labels to keep it clean
 
-  const data = dimensions.map((d) => ({
-    subject: DIMENSION_LABELS[d.dimension] ?? d.label ?? d.dimension,
-    score: d.score,
-    fullMark: 10,
-  }));
+  const data = dimensions.map((d) => {
+    const subject = DIMENSION_LABELS[d.dimension] ?? d.label ?? d.dimension;
+    const point: { subject: string; scoreA: number; fullMark: number; scoreB?: number } = {
+      subject,
+      scoreA: d.score,
+      fullMark: 10,
+    };
+    if (secondDimensions) {
+      const match = secondDimensions.find((s) => s.dimension === d.dimension);
+      point.scoreB = match?.score ?? 0;
+    }
+    return point;
+  });
+
+  const isCompare = !!secondDimensions;
 
   if (!isHero) {
     // Thumbnail: fixed small size is intentional (used in OG/badge contexts, not profile page)
@@ -52,14 +75,25 @@ export default function RadarChart({ dimensions, size = "hero" }: RadarChartProp
         >
           <PolarGrid stroke="rgba(255,255,255,0.1)" />
           <Radar
-            name="Score"
-            dataKey="score"
+            name={labelA}
+            dataKey="scoreA"
             stroke="#6366f1"
             fill="#6366f1"
             fillOpacity={0.25}
             strokeWidth={1.5}
             dot={false}
           />
+          {isCompare && (
+            <Radar
+              name={labelB}
+              dataKey="scoreB"
+              stroke="#f59e0b"
+              fill="#f59e0b"
+              fillOpacity={0.2}
+              strokeWidth={1.5}
+              dot={false}
+            />
+          )}
         </RechartsRadarChart>
       </div>
     );
@@ -67,7 +101,7 @@ export default function RadarChart({ dimensions, size = "hero" }: RadarChartProp
 
   // Hero: use ResponsiveContainer so it never overflows on mobile viewports
   return (
-    <div className="w-full" style={{ height: 320 }}>
+    <div className="w-full" style={{ height: isCompare ? 360 : 320 }}>
       <ResponsiveContainer width="100%" height="100%">
         <RechartsRadarChart
           cx="50%"
@@ -81,14 +115,33 @@ export default function RadarChart({ dimensions, size = "hero" }: RadarChartProp
             tick={{ fill: "rgba(255,255,255,0.8)", fontSize, fontFamily: "Inter, sans-serif" }}
           />
           <Radar
-            name="Score"
-            dataKey="score"
+            name={isCompare ? labelA : "Score"}
+            dataKey="scoreA"
             stroke="#6366f1"
             fill="#6366f1"
-            fillOpacity={0.25}
+            fillOpacity={isCompare ? 0.2 : 0.25}
             strokeWidth={2}
             dot={{ fill: "#6366f1", r: 3 }}
           />
+          {isCompare && (
+            <Radar
+              name={labelB}
+              dataKey="scoreB"
+              stroke="#f59e0b"
+              fill="#f59e0b"
+              fillOpacity={0.2}
+              strokeWidth={2}
+              dot={{ fill: "#f59e0b", r: 3 }}
+            />
+          )}
+          {isCompare && (
+            <Legend
+              wrapperStyle={{ paddingTop: 8, fontSize: 12 }}
+              formatter={(value: string) => (
+                <span style={{ color: "rgba(255,255,255,0.7)" }}>{value}</span>
+              )}
+            />
+          )}
         </RechartsRadarChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## What
Add a publicly accessible profile comparison page at `/compare?a={username}&b={username}`.

## Why
Closes #62

## Acceptance Criteria
- [x] `/compare?a={username}&b={username}` renders a comparison page for two valid usernames
- [x] Page header shows both users' avatars, usernames, composite scores, and tiers
- [x] Single radar chart overlays both users' dimension scores with distinct colors (indigo + amber) and a legend
- [x] Dimension table lists all 6 dimensions showing Score A, Score B, and delta with winner highlighted in bold
- [x] Overall winner (higher composite score) indicated in the header
- [x] Usernames in comparison header link to `/u/{username}`
- [x] If either username not found: shows "Profile not found: {username}"
- [x] "Compare" button entry point on `/u/{username}` profile pages pre-fills current username as `?a=`
- [x] Page is publicly accessible — no auth required
- [x] URL is shareable — query params render the comparison
- [x] Falls back to mock data for demo usernames

## Changes
- `src/app/compare/page.tsx` — new App Router server component, DB + mock fallback, 3-col header, overlaid radar, delta table, error states
- `src/components/CompareButton.tsx` — new client component: collapsed button expands to inline username input, `Enter`/`Escape` keyboard support, routes to `/compare?a=&b=`
- `src/components/RadarChart.tsx` — added optional `secondDimensions`, `labelA`, `labelB` props; renders a second `<Radar>` series and `<Legend>` when provided; non-compare usage unchanged
- `src/app/u/[username]/page.tsx` — imported and added `<CompareButton>` to the share/download buttons row
- `src/app/actions.ts` — extracted signOut server action (fixes pre-existing Next.js 16 build error where inline `use server` in Client Component was blocked by Turbopack)
- `src/components/Navbar.tsx` — updated to use `signOutAction` from actions.ts

## Test Plan
1. Navigate to `/compare?a=wkliwk&b=techuser2` — verify header shows both profiles with winner highlighted, radar chart shows two overlaid traces, delta table has 6 rows
2. Navigate to `/compare?a=nobody&b=ghost` — verify "Profile not found: nobody" and "Profile not found: ghost" error messages shown
3. Navigate to `/compare` (no params) — verify empty state instructional message
4. Visit any profile page (e.g. `/u/wkliwk`) — click "Compare" button, type a username, press Enter — verify redirects to `/compare?a=wkliwk&b={entered}`
5. Share the `/compare` URL — verify loading the URL directly renders the comparison